### PR TITLE
feat(security): add API-key auth and Swagger Authorize for /drafts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
 
-from fastapi import FastAPI
+import os
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.security import APIKeyHeader
 from typing import List
 from .schemas import DraftRequest, DraftResponse
 from .pipeline import build_category_lookup, group_variances, attach_drivers_and_vendors, filter_materiality
@@ -7,12 +9,25 @@ from .gpt_client import generate_draft
 
 app = FastAPI(title="Oaktree Variance Drafts API", version="0.1.0")
 
+# --- API key security (adds "Authorize" in Swagger) --------------------------
+api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
+
+def require_api_key(x_api_key: str = Security(api_key_header)) -> None:
+    expected = os.getenv("API_KEY")
+    if not expected or not x_api_key or x_api_key != expected:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+# -----------------------------------------------------------------------------
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
 
 @app.post("/drafts", response_model=List[DraftResponse])
-def create_drafts(req: DraftRequest):
+def create_drafts(req: DraftRequest, _=Security(require_api_key)):
+    """
+    Create EN/AR variance explanation drafts.
+    """
+    # existing implementation continues…
     cat_lu = build_category_lookup(req.category_map)
     items = group_variances(req.budget_actuals, cat_lu)
     attach_drivers_and_vendors(items, req.change_orders, req.vendor_map, cat_lu)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import csv
+import os
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -26,8 +27,9 @@ def test_create_drafts_endpoint():
         }
     }
 
+    os.environ["API_KEY"] = "testkey"
     client = TestClient(app)
-    resp = client.post('/drafts', json=payload)
+    resp = client.post('/drafts', json=payload, headers={"x-api-key": "testkey"})
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)


### PR DESCRIPTION
## Summary
- require x-api-key header on POST /drafts via FastAPI security dependency
- expose API key scheme so Swagger UI shows padlock Authorize control
- update tests to send x-api-key

## Testing
- `ruff check app/main.py tests/test_api.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b472edb370832a8b21119d9655d6b5