### PR TITLE
feat(ui): serve static demo at /ui

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,12 +2,15 @@
 import os
 from fastapi import FastAPI, HTTPException, Security
 from fastapi.security import APIKeyHeader
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from typing import List
 from .schemas import DraftRequest, DraftResponse
 from .pipeline import build_category_lookup, group_variances, attach_drivers_and_vendors, filter_materiality
 from .gpt_client import generate_draft
 
 app = FastAPI(title="Oaktree Variance Drafts API", version="0.1.0")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 # --- API key security (adds "Authorize" in Swagger) --------------------------
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
@@ -21,6 +24,11 @@ def require_api_key(x_api_key: str = Security(api_key_header)) -> None:
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.get("/ui", include_in_schema=False)
+def ui():
+    return FileResponse(os.path.join("app", "static", "index.html"))
 
 @app.post("/drafts", response_model=List[DraftResponse])
 def create_drafts(req: DraftRequest, _=Security(require_api_key)):


### PR DESCRIPTION
## Summary
- Serve static demo UI by mounting `app/static`
- Add `/ui` route to deliver the index.html

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b48571ab44832ab2ba45bf3abe5553