### PR TITLE
feat(ui): add /ui page and /upload endpoint for CSV-based draft generation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 
 import os
-from fastapi import FastAPI, HTTPException, Security
+import io
+from fastapi import FastAPI, HTTPException, Security, File, UploadFile, Form
 from fastapi.security import APIKeyHeader
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from typing import List
+from typing import List, Optional
+import pandas as pd
 from .schemas import DraftRequest, DraftResponse
 from .pipeline import build_category_lookup, group_variances, attach_drivers_and_vendors, filter_materiality
 from .gpt_client import generate_draft
@@ -45,3 +47,68 @@ def create_drafts(req: DraftRequest, _=Security(require_api_key)):
         en, ar = generate_draft(v, req.config)
         out.append(DraftResponse(variance=v, draft_en=en, draft_ar=ar or None))
     return out
+
+
+@app.post("/upload", include_in_schema=False)
+async def upload(
+    budget_actuals: UploadFile = File(...),
+    change_orders: UploadFile = File(...),
+    vendor_map: UploadFile = File(...),
+    category_map: UploadFile = File(...),
+    materiality_pct: int = Form(5),
+    materiality_amount_sar: int = Form(100000),
+    bilingual: bool = Form(True),
+    enforce_no_speculation: bool = Form(True),
+    api_key: Optional[str] = Form(None),
+):
+    # Optional simple API key check using the same header logic
+    from app.schemas import (
+        DraftRequest,
+        BudgetActualRow,
+        ChangeOrderRow,
+        VendorMapRow,
+        CategoryMapRow,
+        ConfigModel,
+    )
+    from app.pipeline import generate_drafts
+
+    expected = os.getenv("API_KEY")
+    if expected and api_key != expected:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    # Read CSVs
+    ba = await budget_actuals.read()
+    co = await change_orders.read()
+    vm = await vendor_map.read()
+    cm = await category_map.read()
+    df_ba = pd.read_csv(io.BytesIO(ba))
+    df_co = pd.read_csv(io.BytesIO(co))
+    df_vm = pd.read_csv(io.BytesIO(vm))
+    df_cm = pd.read_csv(io.BytesIO(cm))
+
+    # Convert rows to pydantic models
+    ba_rows = [
+        BudgetActualRow(**(r._asdict() if hasattr(r, "_asdict") else dict(r)))
+        for r in df_ba.to_dict(orient="records")
+    ]
+    co_rows = [ChangeOrderRow(**dict(r)) for r in df_co.to_dict(orient="records")]
+    vm_rows = [VendorMapRow(**dict(r)) for r in df_vm.to_dict(orient="records")]
+    cm_rows = [CategoryMapRow(**dict(r)) for r in df_cm.to_dict(orient="records")]
+
+    cfg = ConfigModel(
+        materiality_pct=materiality_pct,
+        materiality_amount_sar=materiality_amount_sar,
+        bilingual=bilingual,
+        enforce_no_speculation=enforce_no_speculation,
+    )
+
+    req = DraftRequest(
+        budget_actuals=ba_rows,
+        change_orders=co_rows,
+        vendor_map=vm_rows,
+        category_map=cm_rows,
+        config=cfg,
+    )
+
+    result = await generate_drafts(req)
+    return result

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2,141 +2,62 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Oaktree Variance Drafts — Demo UI</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Oaktree Variance Drafts</title>
   <style>
-    body { font: 16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; max-width: 960px; }
-    h1 { margin-bottom: 8px; }
-    fieldset { border: 1px solid #ddd; padding: 12px; margin-bottom: 16px; }
-    label { display: block; margin: 6px 0 2px; font-weight: 600; }
-    input[type="number"] { width: 140px; }
-    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .muted { color: #666; font-size: 14px; }
-    pre { background: #0b1020; color: #d1fff3; padding: 12px; overflow: auto; border-radius: 6px; }
-    button { padding: 10px 16px; border: 0; background: #0a66ff; color: white; border-radius: 6px; cursor: pointer; }
-    button:disabled { opacity: .6; cursor: not-allowed; }
+    body { font-family: system-ui, sans-serif; margin: 16px; max-width: 480px; }
+    label { display: block; margin-top: 12px; }
+    input[type="file"], input[type="number"] { width: 100%; }
+    button { margin-top: 16px; padding: 10px 16px; }
+    .variance { padding: 8px 0; border-bottom: 1px solid #ddd; }
+    .variance p { margin: 4px 0; }
+    pre { white-space: pre-wrap; }
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 </head>
 <body>
-  <h1>Oaktree Variance Drafts — Demo</h1>
-  <p class="muted">Upload the four CSVs, set the rules, and click Generate.</p>
-
-  <fieldset>
-    <legend>Connection</legend>
-    <label for="baseUrl">Base URL</label>
-    <input id="baseUrl" type="url" style="width:100%" />
-    <label for="apiKey">API key (<span class="muted">demo only — rotate after</span>)</label>
-    <input id="apiKey" type="password" style="width:100%" />
-  </fieldset>
-
-  <fieldset>
-    <legend>Files</legend>
-    <div class="grid">
-      <div>
-        <label for="ba">Budget–Actuals CSV</label>
-        <input id="ba" type="file" accept=".csv" />
-      </div>
-      <div>
-        <label for="co">Change Orders CSV</label>
-        <input id="co" type="file" accept=".csv" />
-      </div>
-      <div>
-        <label for="vm">Vendor Map CSV</label>
-        <input id="vm" type="file" accept=".csv" />
-      </div>
-      <div>
-        <label for="cm">Category Map CSV</label>
-        <input id="cm" type="file" accept=".csv" />
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Materiality & Style</legend>
-    <div class="grid">
-      <div>
-        <label for="matPct">Materiality % (absolute)</label>
-        <input id="matPct" type="number" value="5" min="0" step="0.5" />
-      </div>
-      <div>
-        <label for="matAmt">Materiality amount (SAR)</label>
-        <input id="matAmt" type="number" value="100000" min="0" step="10000" />
-      </div>
-    </div>
-    <div style="margin-top:8px;">
-      <label><input id="bilingual" type="checkbox" checked /> Generate EN + AR</label>
-      <label><input id="noSpec" type="checkbox" checked /> No speculation (documented drivers only)</label>
-    </div>
-  </fieldset>
-
-  <button id="goBtn">Generate drafts</button>
-
-  <h2 style="margin-top:24px;">Result</h2>
-  <pre id="out">(no result yet)</pre>
-
+  <h1>Upload CSVs</h1>
+  <form id="form">
+    <label>Budget–Actuals CSV
+      <input type="file" name="budget_actuals" accept=".csv" required>
+    </label>
+    <label>Change Orders CSV
+      <input type="file" name="change_orders" accept=".csv" required>
+    </label>
+    <label>Vendor Map CSV
+      <input type="file" name="vendor_map" accept=".csv" required>
+    </label>
+    <label>Category Map CSV
+      <input type="file" name="category_map" accept=".csv" required>
+    </label>
+    <label>Materiality %
+      <input type="number" name="materiality_pct" value="5">
+    </label>
+    <label>Materiality amount (SAR)
+      <input type="number" name="materiality_amount_sar" value="100000">
+    </label>
+    <label><input type="checkbox" name="bilingual" checked> Bilingual</label>
+    <label><input type="checkbox" name="enforce_no_speculation" checked> No speculation</label>
+    <button type="submit">Generate</button>
+  </form>
+  <div id="out"></div>
   <script>
-    const $ = id => document.getElementById(id);
-    window.addEventListener('DOMContentLoaded', () => {
-      $('baseUrl').value = window.location.origin;
-    });
-
-    function parseCSV(file) {
-      return new Promise((resolve, reject) => {
-        Papa.parse(file, {
-          header: true,
-          skipEmptyLines: true,
-          complete: results => resolve(results.data),
-          error: err => reject(err)
-        });
+    const form = document.getElementById('form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const out = document.getElementById('out');
+      out.textContent = 'Processing...';
+      const data = new FormData(form);
+      const resp = await fetch('/upload', { method: 'POST', body: data });
+      const json = await resp.json();
+      out.innerHTML = '';
+      json.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'variance';
+        div.innerHTML = `<p><strong>EN:</strong> ${item.draft_en}</p>` +
+          (item.draft_ar ? `<p><strong>AR:</strong> ${item.draft_ar}</p>` : '');
+        out.appendChild(div);
       });
-    }
-
-    async function generate() {
-      const btn = $('goBtn');
-      btn.disabled = true;
-      $('out').textContent = 'Processing…';
-
-      try {
-        const [ba, co, vm, cm] = await Promise.all([
-          parseCSV($('ba').files[0]),
-          parseCSV($('co').files[0]),
-          parseCSV($('vm').files[0]),
-          parseCSV($('cm').files[0]),
-        ]);
-
-        const body = {
-          budget_actuals: ba,
-          change_orders: co,
-          vendor_map: vm,
-          category_map: cm,
-          config: {
-            materiality_pct: Number($('matPct').value),
-            materiality_amount_sar: Number($('matAmt').value),
-            bilingual: $('bilingual').checked,
-            enforce_no_speculation: $('noSpec').checked
-          }
-        };
-
-        const resp = await fetch(`${$('baseUrl').value}/drafts`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-api-key': $('apiKey').value.trim()
-          },
-          body: JSON.stringify(body)
-        });
-
-        const json = await resp.json();
-        $('out').textContent = JSON.stringify(json, null, 2);
-      } catch (e) {
-        $('out').textContent = 'Error: ' + (e?.message || e);
-      } finally {
-        btn.disabled = false;
-      }
-    }
-
-    $('goBtn').addEventListener('click', generate);
+    });
   </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ requests==2.32.4
 pytest==8.4.1
 ruff==0.12.10
 mypy==1.17.1
+pandas
+python-multipart


### PR DESCRIPTION
## Summary
- add async `/upload` endpoint to parse CSVs and generate drafts
- add simple mobile-friendly upload page
- include pandas and python-multipart dependencies

## Testing
- `ruff check app/main.py app/pipeline.py`
- `mypy app` *(fails: Missing stubs for pydantic, fastapi, pandas)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b488495fc8832a8acc1ff7c57615e4