### PR TITLE
Auth: allow demo without API key via REQUIRE_API_KEY=false

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,9 @@ import csv
 import os
 from pathlib import Path
 
+os.environ["API_KEY"] = "testkey"
+os.environ["REQUIRE_API_KEY"] = "true"
+
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -27,7 +30,6 @@ def test_create_drafts_endpoint():
         }
     }
 
-    os.environ["API_KEY"] = "testkey"
     client = TestClient(app)
     resp = client.post('/drafts', json=payload, headers={"x-api-key": "testkey"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Make API key enforcement optional via REQUIRE_API_KEY env
- Derive optional dependency list for routes
- Adjust tests to configure API_KEY before importing app

## Testing
- `ruff check app/main.py tests/test_api.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48de2bbbc832aa05f95df82eba47d