### PR TITLE
Handle UI errors and API key input for draft generation

### DIFF
--- a/app/prompt_contract.py
+++ b/app/prompt_contract.py
@@ -1,5 +1,4 @@
 
-from typing import Tuple
 from .schemas import VarianceItem, ConfigModel
 
 SYSTEM_PROMPT = (

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -37,6 +37,9 @@
     </label>
     <label><input type="checkbox" name="bilingual" checked> Bilingual</label>
     <label><input type="checkbox" name="enforce_no_speculation" checked> No speculation</label>
+    <label>API Key
+      <input type="password" name="api_key">
+    </label>
     <button type="submit">Generate</button>
   </form>
   <div id="out"></div>
@@ -46,17 +49,30 @@
       e.preventDefault();
       const out = document.getElementById('out');
       out.textContent = 'Processing...';
-      const data = new FormData(form);
-      const resp = await fetch('/upload', { method: 'POST', body: data });
-      const json = await resp.json();
-      out.innerHTML = '';
-      json.forEach(item => {
-        const div = document.createElement('div');
-        div.className = 'variance';
-        div.innerHTML = `<p><strong>EN:</strong> ${item.draft_en}</p>` +
-          (item.draft_ar ? `<p><strong>AR:</strong> ${item.draft_ar}</p>` : '');
-        out.appendChild(div);
-      });
+      try {
+        const data = new FormData(form);
+        const resp = await fetch('/upload', { method: 'POST', body: data });
+        if (!resp.ok) {
+          const text = await resp.text();
+          out.textContent = `Error: ${resp.status} ${text}`;
+          return;
+        }
+        const json = await resp.json();
+        if (!Array.isArray(json)) {
+          out.textContent = `Unexpected response: ${JSON.stringify(json)}`;
+          return;
+        }
+        out.innerHTML = '';
+        json.forEach(item => {
+          const div = document.createElement('div');
+          div.className = 'variance';
+          div.innerHTML = `<p><strong>EN:</strong> ${item.draft_en}</p>` +
+            (item.draft_ar ? `<p><strong>AR:</strong> ${item.draft_ar}</p>` : '');
+          out.appendChild(div);
+        });
+      } catch (err) {
+        out.textContent = `Error: ${err.message}`;
+      }
     });
   </script>
 </body>

--- a/scripts/load_csv_and_post.py
+++ b/scripts/load_csv_and_post.py
@@ -1,19 +1,37 @@
 #!/usr/bin/env python3
-import csv, json, os, sys, requests
+import csv
+import json
+import os
+import sys
+
+import requests
+
 API = os.getenv("MVP_API", "http://localhost:8000/drafts")
+
+
 def read_csv(path):
-    with open(path, newline='', encoding='utf-8') as f:
+    with open(path, newline="", encoding="utf-8") as f:
         return list(csv.DictReader(f))
+
+
 def main(folder):
     payload = {
         "budget_actuals": read_csv(os.path.join(folder, "budget_actuals.csv")),
         "change_orders": read_csv(os.path.join(folder, "change_orders.csv")),
         "vendor_map": read_csv(os.path.join(folder, "vendor_map.csv")),
         "category_map": read_csv(os.path.join(folder, "category_map.csv")),
-        "config": {"materiality_pct": 5.0, "materiality_amount_sar": 100000, "bilingual": True, "enforce_no_speculation": True}
+        "config": {
+            "materiality_pct": 5.0,
+            "materiality_amount_sar": 100000,
+            "bilingual": True,
+            "enforce_no_speculation": True,
+        },
     }
-    r = requests.post(API, json=payload, timeout=30); r.raise_for_status()
+    r = requests.post(API, json=payload, timeout=30)
+    r.raise_for_status()
     print(json.dumps(r.json(), ensure_ascii=False, indent=2))
+
+
 if __name__ == "__main__":
     folder = sys.argv[1] if len(sys.argv) > 1 else "data/templates"
     main(folder)


### PR DESCRIPTION
## Summary
- add API key field and robust error handling to web UI
- clean up unused imports and script style issues

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49c289684832a9cdf5485a5029215