### PR TITLE
Add upload endpoint test and handle empty CSV fields

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -151,10 +151,10 @@ async def upload(
     co = await change_orders.read()
     vm = await vendor_map.read()
     cm = await category_map.read()
-    df_ba = pd.read_csv(io.BytesIO(ba))
-    df_co = pd.read_csv(io.BytesIO(co))
-    df_vm = pd.read_csv(io.BytesIO(vm))
-    df_cm = pd.read_csv(io.BytesIO(cm))
+    df_ba = pd.read_csv(io.BytesIO(ba)).fillna("")
+    df_co = pd.read_csv(io.BytesIO(co)).fillna("")
+    df_vm = pd.read_csv(io.BytesIO(vm)).fillna("")
+    df_cm = pd.read_csv(io.BytesIO(cm)).fillna("")
 
     # Convert rows to pydantic models
     ba_rows = [

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,37 @@
+import os
+from pathlib import Path
+
+os.environ["API_KEY"] = "testkey"
+os.environ["REQUIRE_API_KEY"] = "true"
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_upload_endpoint():
+    client = TestClient(app)
+    base = Path("data/templates")
+    with (
+        (base / "budget_actuals.csv").open("rb") as ba,
+        (base / "change_orders.csv").open("rb") as co,
+        (base / "vendor_map.csv").open("rb") as vm,
+        (base / "category_map.csv").open("rb") as cm,
+    ):
+        files = {
+            "budget_actuals": ("budget_actuals.csv", ba, "text/csv"),
+            "change_orders": ("change_orders.csv", co, "text/csv"),
+            "vendor_map": ("vendor_map.csv", vm, "text/csv"),
+            "category_map": ("category_map.csv", cm, "text/csv"),
+        }
+        data = {
+            "materiality_pct": "5",
+            "materiality_amount_sar": "100000",
+            "bilingual": "true",
+            "enforce_no_speculation": "true",
+            "api_key": "testkey",
+        }
+        resp = client.post("/upload", files=files, data=data)
+    assert resp.status_code == 200
+    result = resp.json()
+    assert isinstance(result, list)
+    assert all("draft_en" in item for item in result)


### PR DESCRIPTION
## Summary
- sanitize uploaded CSV files to replace missing values before pydantic conversion
- add test ensuring `/upload` endpoint processes CSV inputs successfully

## Testing
- `ruff check tests/test_upload.py app`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49d984180832a8c734676cf9be6d0