### PR TITLE
Handle OpenAI timeouts in draft generation

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -86,9 +86,13 @@ def filter_materiality(items: List[VarianceItem], cfg: ConfigModel) -> List[Vari
     return [v for v in items if abs(v.variance_pct) >= cfg.materiality_pct or abs(v.variance_sar) >= cfg.materiality_amount_sar]
 
 
+def _noop_progress(pct: int, msg: str = "") -> None:
+    return None
+
+
 def generate_drafts(
     req: DraftRequest,
-    progress_cb: Callable[[int, str], None] = lambda pct, msg="": None,
+    progress_cb: Callable[[int, str], None] = _noop_progress,
 ) -> List[DraftResponse]:
     """High-level helper to build drafts from CSV-derived models."""
     progress_cb(10, "Loading & validating input")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,0 +1,44 @@
+import os
+from app.gpt_client import generate_draft
+from app.schemas import VarianceItem, ConfigModel
+
+class DummyOpenAI:
+    last_kwargs = None
+
+    def __init__(self, api_key: str, timeout: int, max_retries: int):
+        DummyOpenAI.last_kwargs = {
+            "api_key": api_key,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
+        class _Chat:
+            class _Completions:
+                def create(self, *args, **kwargs):
+                    raise TimeoutError("boom")
+            completions = _Completions()
+        self.chat = _Chat()
+
+def test_generate_draft_timeout(monkeypatch):
+    os.environ["OPENAI_API_KEY"] = "sk-test"
+    os.environ["OPENAI_TIMEOUT"] = "1"
+    monkeypatch.setattr("openai.OpenAI", DummyOpenAI)
+
+    v = VarianceItem(
+        project_id="P1",
+        period="2024-01",
+        category="Materials",
+        budget_sar=1000.0,
+        actual_sar=1200.0,
+        variance_sar=200.0,
+        variance_pct=20.0,
+        drivers=["CO-1"],
+        vendors=["Vendor"],
+    )
+    cfg = ConfigModel()
+    en, ar = generate_draft(v, cfg)
+    assert "variance" in en
+    assert DummyOpenAI.last_kwargs["timeout"] == 1
+    assert DummyOpenAI.last_kwargs["max_retries"] == 0
+    assert ar  # bilingual fallback text
+    os.environ.pop("OPENAI_API_KEY")
+    os.environ.pop("OPENAI_TIMEOUT")


### PR DESCRIPTION
## Summary
- Avoid hangs by applying configurable timeout and no retries when calling OpenAI
- Provide no-op progress callback helper
- Add regression test for OpenAI timeout fallback

## Testing
- `ruff check app tests`
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. mypy app tests`


------
https://chatgpt.com/codex/tasks/task_e_68b49f61938c832ab881df30ca5bb8a9