### PR TITLE
Add CSV/Excel upload endpoint for variance drafts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests>=2.31
 pytest==8.4.1
 ruff==0.12.10
 mypy==1.17.1
+openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- add `/drafts/upload` endpoint to parse CSV or Excel inputs and generate variance drafts
- support UTF-8 and Latin-1 CSV decoding with pandas and Excel files via openpyxl
- include openpyxl dependency

## Testing
- `ruff check app/main.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bcd82af0832aa7a9d8d8225cf074