### PR TITLE
Add Excel upload support and improve output formatting

### DIFF
--- a/scripts/load_csv_and_post.py
+++ b/scripts/load_csv_and_post.py
@@ -1,25 +1,52 @@
 #!/usr/bin/env python3
 import csv
-import json
 import os
 import sys
+from typing import List, Dict
 
+import pandas as pd
 import requests
 
 API = os.getenv("MVP_API", "http://localhost:8000/drafts")
 
 
-def read_csv(path):
-    with open(path, newline="", encoding="utf-8") as f:
-        return list(csv.DictReader(f))
+def read_table(folder: str, name: str) -> List[Dict]:
+    """Read ``name`` with .csv/.xls/.xlsx extension from ``folder``."""
+    for ext in (".csv", ".xls", ".xlsx"):
+        path = os.path.join(folder, name + ext)
+        if os.path.exists(path):
+            if ext == ".csv":
+                with open(path, newline="", encoding="utf-8") as f:
+                    return list(csv.DictReader(f))
+            df = pd.read_excel(path)
+            return df.fillna("").to_dict(orient="records")
+    raise FileNotFoundError(f"Missing file for {name} (csv/xls/xlsx)")
 
 
-def main(folder):
+def pretty_print(result: List[Dict]) -> None:
+    for i, item in enumerate(result, 1):
+        v = item.get("variance", {})
+        print(
+            f"{i}. Project {v.get('project_id')} | {v.get('period')} | {v.get('category')}"
+        )
+        print(
+            f"   Budget: {v.get('budget_sar')} | Actual: {v.get('actual_sar')} | "
+            f"Variance: {v.get('variance_sar')} ({v.get('variance_pct'):.2f}%)"
+        )
+        print(f"   EN: {item.get('draft_en')}")
+        if item.get("draft_ar"):
+            print(f"   AR: {item.get('draft_ar')}")
+        if item.get("analyst_notes"):
+            print(f"   Notes: {item.get('analyst_notes')}")
+        print()
+
+
+def main(folder: str) -> None:
     payload = {
-        "budget_actuals": read_csv(os.path.join(folder, "budget_actuals.csv")),
-        "change_orders": read_csv(os.path.join(folder, "change_orders.csv")),
-        "vendor_map": read_csv(os.path.join(folder, "vendor_map.csv")),
-        "category_map": read_csv(os.path.join(folder, "category_map.csv")),
+        "budget_actuals": read_table(folder, "budget_actuals"),
+        "change_orders": read_table(folder, "change_orders"),
+        "vendor_map": read_table(folder, "vendor_map"),
+        "category_map": read_table(folder, "category_map"),
         "config": {
             "materiality_pct": 5.0,
             "materiality_amount_sar": 100000,
@@ -29,7 +56,7 @@ def main(folder):
     }
     r = requests.post(API, json=payload, timeout=30)
     r.raise_for_status()
-    print(json.dumps(r.json(), ensure_ascii=False, indent=2))
+    pretty_print(r.json())
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -1,4 +1,7 @@
-from app.services.csv_loader import parse_csv
+from io import BytesIO
+import pandas as pd
+
+from app.services.csv_loader import parse_csv, parse_tabular
 
 
 def test_parse_csv_maps_synonyms():
@@ -11,3 +14,13 @@ def test_parse_csv_skips_blank_rows():
     data = b"period,category\n2024-01,Alpha\n,\n"
     rows = parse_csv(data)
     assert rows == [{"period": "2024-01", "category": "Alpha"}]
+
+
+def test_parse_tabular_excel():
+    df = pd.DataFrame(
+        [{"project_id": 1, "period(YYYY-MM)": "2024-05", "value": 100}]
+    )
+    buf = BytesIO()
+    df.to_excel(buf, index=False)
+    rows = parse_tabular(buf.getvalue(), "test.xlsx")
+    assert rows == [{"project_id": 1, "period": "2024-05", "value": 100}]


### PR DESCRIPTION
## Summary
- allow CSV or Excel uploads by adding `parse_tabular` and updating API endpoints
- enhance upload tests and parsing tests to cover Excel files
- rewrite helper script to read Excel and print human-friendly draft summaries

## Testing
- `ruff check app/main.py app/services/csv_loader.py scripts/load_csv_and_post.py tests/test_csv_loader.py tests/test_upload.py tests/conftest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c04c33c0832a95cd56edc82cfa47