### PR TITLE
Improve Excel handling and UI formatting

### DIFF
--- a/app/services/csv_loader.py
+++ b/app/services/csv_loader.py
@@ -22,7 +22,21 @@ def _canonicalize_headers(headers: List[str]) -> List[str]:
     return canon
 
 def parse_csv(upload_bytes: bytes) -> List[Dict]:
-    text = upload_bytes.decode("utf-8-sig")
+    """Parse CSV bytes into row dicts, with Excel fallback.
+
+    Historically this helper only handled UTF-8 encoded ``.csv`` files. Some
+    users, however, may accidentally upload Excel binaries (``.xls``/``.xlsx``)
+    to endpoints expecting CSV. To make the service more forgiving, we attempt
+    to decode as UTF-8 first and, on failure, fall back to the more flexible
+    :func:`parse_tabular` using an Excel parser.
+    """
+
+    try:
+        text = upload_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        # Likely an Excel file; delegate to parse_tabular for robustness
+        return parse_tabular(upload_bytes, "upload.xlsx")
+
     reader = csv.reader(io.StringIO(text))
     rows = list(reader)
     if not rows:
@@ -32,7 +46,7 @@ def parse_csv(upload_bytes: bytes) -> List[Dict]:
     for r in rows[1:]:
         if not any(x.strip() for x in r):
             continue
-        out.append({headers[i]: r[i].strip() if i < len(r) else "" for i in range(len(headers))})
+        out.append({headers[i]: r[i].strip() if i < len(headers) else "" for i in range(len(headers))})
     return out
 
 

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -104,10 +104,6 @@
 
     <div class="card">
       <div id="result"></div>
-      <details>
-        <summary>Raw JSON (for analysts)</summary>
-        <pre id="out">{}</pre>
-      </details>
     </div>
   </div>
 
@@ -292,7 +288,6 @@
 
       const data = await resp.json();
       setStatus('Done', 'ok'); setBar(100);
-      $('out').textContent = JSON.stringify(data, null, 2);
       renderResult(data);
     } catch (err) {
       setStatus(String(err && err.message ? err.message : err), 'err');
@@ -309,8 +304,17 @@
     const container = document.createElement('div');
     container.className = 'report';
 
+    // Order variances consistently by project, period, then category
+    items.sort((a, b) => {
+      const va = a.variance ?? a;
+      const vb = b.variance ?? b;
+      return (va.project_id || '').localeCompare(vb.project_id || '') ||
+             (va.period || '').localeCompare(vb.period || '') ||
+             (va.category || '').localeCompare(vb.category || '');
+    });
+
     if (!items.length) {
-      $('result').textContent = JSON.stringify(data ?? {}, null, 2);
+      $('result').textContent = 'No variance items found.';
       return;
     }
 

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -24,3 +24,14 @@ def test_parse_tabular_excel():
     df.to_excel(buf, index=False)
     rows = parse_tabular(buf.getvalue(), "test.xlsx")
     assert rows == [{"project_id": 1, "period": "2024-05", "value": 100}]
+
+
+def test_parse_csv_excel_fallback():
+    """Binary Excel uploads should still be parsed by parse_csv."""
+    df = pd.DataFrame(
+        [{"project_id": 2, "period(YYYY-MM)": "2024-06", "value": 200}]
+    )
+    buf = BytesIO()
+    df.to_excel(buf, index=False)
+    rows = parse_csv(buf.getvalue())
+    assert rows == [{"project_id": 2, "period": "2024-06", "value": 200}]


### PR DESCRIPTION
## Summary
- Allow `parse_csv` to gracefully fall back to parsing Excel files
- Sort variance results and drop raw JSON from the UI for a cleaner report
- Test Excel handling directly via `parse_csv`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d4fefd84832a8f4c43d10ae156b9