### PR TITLE
Add single-file upload track with LLM fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 3) Draft investor-ready explanations (EN/AR) using a prompt contract
 4) Return JSON drafts for analyst review (with evidence links)
 
+The app supports two mutually-exclusive upload modes:
+
+- **Structured track** – provide four CSV/Excel files (budget–actuals, change orders, vendor map, category map).
+- **Freeform track** – provide a single CSV/Excel/Word/PDF/text file. The app will attempt to extract rows and totals using deterministic parsing with an LLM fallback.
+
 ## Run
 ```
 pip install fastapi uvicorn pydantic openai

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -104,6 +104,15 @@
 
     <div class="card">
       <div class="field">
+        <label>Single Data File (CSV, Excel, Word, PDF, or Text)</label>
+        <input id="fSingle" type="file" accept=".csv,.xlsx,.xls,.pdf,.docx,.txt,.md,.rtf" />
+        <div class="hint">Use this for incomplete or messy data in one file. Uploading here disables the 4-file track.</div>
+        <button id="btnSingle" class="btn" style="margin-top:8px">Generate from file</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="field">
         <label>Procurement PDFs (optional)</label>
         <input id="proc_pdfs" type="file" accept="application/pdf" multiple />
         <div class="hint">Upload quotes/PRs. The app will extract amounts and descriptions that exist in the documents (no invention).</div>
@@ -337,9 +346,51 @@
 
   $('btnExtract').addEventListener('click', extractProcurement);
 
+  function trackToggle() {
+    const single = $('fSingle');
+    const others = ['fBudget','fCO','fVendor','fCat'].map(id => $(id));
+    const singleActive = single.files.length > 0;
+    others.forEach(inp => inp.disabled = singleActive);
+    single.disabled = others.some(inp => inp.files.length > 0);
+  }
+  ['fSingle','fBudget','fCO','fVendor','fCat'].forEach(id => {
+    $(id).addEventListener('change', trackToggle);
+  });
+  trackToggle();
+
+  $('btnSingle').addEventListener('click', async () => {
+    try {
+      if (['fBudget','fCO','fVendor','fCat'].some(id => $(id).files.length)) {
+        setStatus('Clear the structured uploads to use the single file mode.', 'err');
+        return;
+      }
+      const f = $('fSingle').files[0];
+      if (!f) { setStatus('Please choose a file.', 'err'); return; }
+      setStatus('Uploading…'); setBar(25); $('btnSingle').disabled=true;
+      const fd = new FormData(); fd.append('data_file', f);
+      const resp = await fetch('/upload', { method:'POST', body: fd });
+      if (!resp.ok) {
+        const txt = await resp.text();
+        setStatus('API error: ' + resp.status + ' ' + resp.statusText + '\n' + txt, 'err');
+        setBar(0); $('btnSingle').disabled=false; return;
+      }
+      const data = await resp.json();
+      setStatus('Done','ok'); setBar(100);
+      $('result').textContent = JSON.stringify(data,null,2);
+    } catch (err) {
+      setStatus(String(err && err.message ? err.message : err), 'err'); setBar(0);
+    } finally {
+      $('btnSingle').disabled=false; setTimeout(()=>setBar(0),1200);
+    }
+  });
+
   // ---------- Main click ----------
   $('btnGen').addEventListener('click', async () => {
     try {
+      if ($('fSingle').files.length) {
+        setStatus('Remove the single data file to use the structured track.', 'err');
+        return;
+      }
       setStatus('Reading files…'); setBar(10); $('btnGen').disabled = true;
 
       const [baRows, coRows, vmRows, cmRows] = await Promise.all([


### PR DESCRIPTION
## Summary
- support mutually exclusive structured and freeform upload modes
- allow generating reports from a single file using tolerant parsing and LLM extraction
- extend UI with fifth upload box and single-file generation button
- cover freeform mode and exclusivity with tests

## Testing
- `ruff check .`
- `pytest tests/test_upload.py::test_upload_single_data_file -q`
- `pytest tests/test_upload.py::test_upload_mutual_exclusive -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b721b38c00832ab637504066408614