### PR TITLE
Add two-track upload report spec v2 with normalized Track B output

### DIFF
--- a/two-track-upload-report-v2.yaml
+++ b/two-track-upload-report-v2.yaml
@@ -1,0 +1,298 @@
+name: two-track-upload-report-v2
+label: "Two-Track Upload → Report (fixed Track B)"
+description: >
+  Two mutually-exclusive tracks:
+  (A) four structured files, or (B) one flexible file.
+  Track B now returns normalized CSV + markdown report (no raw JSON),
+  and both tracks keep a strict no-invention policy.
+
+ui:
+  layout: vertical
+  sections:
+    - id: track_a
+      label: "Track A — Structured (4 files)"
+      inputs:
+        - id: file_budget_actuals
+          type: file
+          label: "Budget & Actuals (CSV/XLSX)"
+          accept: [".csv",".xlsx"]
+        - id: file_forecast
+          type: file
+          label: "Forecast (CSV/XLSX)"
+          accept: [".csv",".xlsx"]
+        - id: file_master_metrics
+          type: file
+          label: "Master Metrics / Dimensions (CSV/XLSX)"
+          accept: [".csv",".xlsx"]
+        - id: file_mapping
+          type: file
+          label: "Mappings (CSV/XLSX)"
+          accept: [".csv",".xlsx"]
+      helpers:
+        - type: note
+          text: "Mutually exclusive with Track B. Leave these empty if you use Track B."
+
+    - id: track_b
+      label: "Track B — Flexible (1 file: CSV/XLSX/PDF/DOC/TXT)"
+      inputs:
+        - id: file_flexible
+          type: file
+          label: "Single Flexible Upload"
+          accept: [".csv",".xlsx",".xls",".pdf",".doc",".docx",".txt",".md",".json"]
+      helpers:
+        - type: note
+          text: "For incomplete or messy files. Mutually exclusive with Track A."
+
+    - id: run
+      inputs:
+        - id: generate
+          type: button
+          label: "Generate Report"
+          style: primary
+          on_click:
+            action: run-two-track
+
+logic:
+  # Hard exclusivity: can’t provide Track A and B together.
+  # Priority: B if provided; else require all four A files.
+  notes:
+    - "LLM may clean/parse but must NEVER invent or infer numbers not present."
+
+actions:
+  - id: run-two-track
+    type: workflow
+    steps:
+      - id: exclusivity_check
+        type: branch
+        branches:
+          - when: >-
+              {{
+                inputs.file_flexible and
+                (inputs.file_budget_actuals or inputs.file_forecast or inputs.file_master_metrics or inputs.file_mapping)
+              }}
+            goto: exclusivity_error
+          - when: "{{ inputs.file_flexible }}"
+            goto: track_b_pipeline
+          - when: "{{ inputs.file_budget_actuals and inputs.file_forecast and inputs.file_master_metrics and inputs.file_mapping }}"
+            goto: track_a_pipeline
+          - else:
+            goto: missing_inputs_error
+
+      # ===================== TRACK B (fixed) =====================
+      - id: track_b_pipeline
+        type: subworkflow
+        steps:
+          - id: extract_from_single
+            type: llm_extract
+            model: gpt-4o
+            files:
+              - "{{ inputs.file_flexible }}"
+            prompt: |
+              ROLE: Finance data wrangler.
+              INPUT: One file (PDF/Word/CSV/Excel/Text/JSON). May be scanned or messy.
+              TASK:
+                • Extract ONLY fields that truly exist; never invent.
+                • Prefer an items table if present. Target headers:
+                  ["description","qty","unit","unit_price_sar","line_total_sar"] (use any real subset found).
+                • Normalize numbers (strip currency symbols/commas; use decimals).
+                • Drop decorative/header-only lines.
+                • If you must rename a header, FLAG it in notes.
+              OUTPUTS:
+                normalized_csv: CSV text (UTF-8). Include at least "description".
+                notes: Bullets of assumptions + exact refs (page/line/sheet/column).
+              HARD RULES:
+                - No hallucinations. No synthetic rows/amounts. Leave missing values blank and note them.
+
+          - id: sanitize_csv
+            type: tabular_transform
+            code: |
+              T = READ_CSV(extract_from_single.outputs.normalized_csv)
+              T = STRIP_WHITESPACE(T)
+              # keep rows that have any signal
+              T = DROP_EMPTY_ROWS(T, keep_if_any_of=["description","qty","unit","unit_price_sar","line_total_sar"])
+              # coerce numerics if columns exist
+              T = COERCE_NUMERIC(T, cols=[c for c in ["qty","unit_price_sar","line_total_sar"] if c in T.columns])
+              # compute line_total_sar if missing but qty & unit_price_sar exist
+              if ("line_total_sar" not in T.columns) and ("qty" in T.columns) and ("unit_price_sar" in T.columns):
+                  T["line_total_sar"] = SAFE_MUL(T["qty"], T["unit_price_sar"])
+              OUT = T
+
+          - id: analyze_single
+            type: llm_analyze
+            model: gpt-4o
+            inputs:
+              csv: "{{ steps.sanitize_csv.outputs.OUT }}"
+              notes: "{{ steps.extract_from_single.outputs.notes }}"
+            prompt: |
+              ROLE: Procurement/variance analyst.
+              Using the CSV and notes:
+                - If "line_total_sar" exists, compute grand total and top 10 lines by amount.
+                - Else if qty & unit_price_sar exist, use qty*unit_price_sar for amounts.
+                - If no numeric fields, report qualitative insights from "description" only.
+                - List data gaps and assumptions clearly.
+              HARD RULES:
+                - Evidence-only. No invented figures or backfilled numbers.
+              OUTPUT SECTIONS:
+                1) Executive Summary
+                2) Key Line Items / Totals
+                3) Observations & Trends
+                4) Data Gaps & Assumptions
+
+          - id: deliver_b
+            type: result
+            outputs:
+              report_markdown: "{{ steps.analyze_single.outputs.text }}"
+              normalized_csv: "{{ steps.sanitize_csv.outputs.OUT }}"
+              data_notes: "{{ steps.extract_from_single.outputs.notes }}"
+
+      # ===================== TRACK A (unchanged but LLM-assisted) =====================
+      - id: track_a_pipeline
+        type: subworkflow
+        steps:
+          - id: load_csvs
+            type: tabular_load
+            files:
+              - id: budget_actuals
+                file: "{{ inputs.file_budget_actuals }}"
+              - id: forecast
+                file: "{{ inputs.file_forecast }}"
+              - id: master_metrics
+                file: "{{ inputs.file_master_metrics }}"
+              - id: mapping
+                file: "{{ inputs.file_mapping }}"
+
+          - id: llm_harmonize_headers
+            type: llm_extract
+            model: gpt-4o
+            files:
+              - "{{ inputs.file_budget_actuals }}"
+              - "{{ inputs.file_forecast }}"
+              - "{{ inputs.file_master_metrics }}"
+              - "{{ inputs.file_mapping }}"
+            prompt: |
+              ROLE: Data harmonizer.
+              Map source headers to canonical: period, account, cost_center, amount, type, forecast_amount, currency, source.
+              DO NOT fabricate columns. Mark missing canon fields as absent.
+              OUTPUTS: header_mappings (per file), harmonization_notes.
+
+          - id: apply_header_mapping
+            type: tabular_transform
+            code: |
+              OUT_budget_actuals = APPLY_HEADERS(budget_actuals, llm_harmonize_headers.outputs.header_mappings['budget_actuals'])
+              OUT_forecast       = APPLY_HEADERS(forecast,       llm_harmonize_headers.outputs.header_mappings['forecast'])
+              OUT_master         = APPLY_HEADERS(master_metrics, llm_harmonize_headers.outputs.header_mappings['master_metrics'])
+              OUT_mapping        = APPLY_HEADERS(mapping,        llm_harmonize_headers.outputs.header_mappings['mapping'])
+
+          - id: validate_shape
+            type: tabular_validate
+            rules:
+              - ensure_columns_any_of:
+                  table: OUT_budget_actuals
+                  sets:
+                    - ["period","account","cost_center","amount","type"]
+                    - ["Period","Account","Cost Center","Amount","Type"]
+              - ensure_columns_any_of:
+                  table: OUT_forecast
+                  sets:
+                    - ["period","account","cost_center","forecast_amount"]
+                    - ["Period","Account","Cost Center","Forecast Amount"]
+              - soft_warn_missing: true
+
+          - id: llm_clean_transform
+            type: llm_analyze
+            model: gpt-4o
+            inputs:
+              budget_actuals_preview: "{{ steps.apply_header_mapping.outputs.OUT_budget_actuals | head(1000) }}"
+              forecast_preview: "{{ steps.apply_header_mapping.outputs.OUT_forecast | head(1000) }}"
+              notes: "{{ steps.llm_harmonize_headers.outputs.harmonization_notes }}"
+            prompt: |
+              Suggest NON-DESTRUCTIVE cleanups (date parsing, trimming, currency symbol removal).
+              Identify safe join keys (default to period,account,cost_center). No filling with guesses.
+              OUTPUTS: cleaning_suggestions, join_keys
+
+          - id: compute_variance
+            type: tabular_transform
+            code: |
+              budget = FILTER(OUT_budget_actuals, type == "budget")
+              actual = FILTER(OUT_budget_actuals, type == "actual")
+              keys = llm_clean_transform.outputs.join_keys or ["period","account","cost_center"]
+              joined = JOIN(actual, budget, on=keys, how="inner", suffixes=("_actual","_budget"))
+              with_forecast = LEFT_JOIN(joined, OUT_forecast, on=keys)
+              with_variance = with_forecast.assign(
+                  variance_amount = if_present(amount_actual, amount_budget, amount_actual - amount_budget),
+                  variance_pct    = if_present(amount_actual, amount_budget, safe_divide(amount_actual - amount_budget, NULLIFZERO(amount_budget)))
+              )
+              enriched = LEFT_JOIN(with_variance, OUT_master, on=keys)
+              enriched = LEFT_JOIN(enriched, OUT_mapping, on=keys)
+              OUT = enriched
+
+          - id: summarize
+            type: llm_analyze
+            model: gpt-4o
+            inputs:
+              table: "{{ steps.compute_variance.outputs.OUT }}"
+              cleaning_suggestions: "{{ steps.llm_clean_transform.outputs.cleaning_suggestions }}"
+              harmonization_notes: "{{ steps.llm_harmonize_headers.outputs.harmonization_notes }}"
+            prompt: |
+              Produce:
+                1) Executive Summary
+                2) Top 10 unfavorable & favorable variances (only where both actual and budget exist)
+                3) Period trends
+                4) Segment insights
+                5) Data Quality & Assumptions
+              HARD RULES:
+                - Evidence-only; do not invent or backfill numbers.
+
+          - id: deliver_a
+            type: result
+            outputs:
+              report_markdown: "{{ steps.summarize.outputs.text }}"
+              variance_table: "{{ steps.compute_variance.outputs.OUT }}"
+              audit_trail: |
+                ## Harmonization
+                {{ steps.llm_harmonize_headers.outputs.harmonization_notes }}
+                ## Cleaning
+                {{ steps.llm_clean_transform.outputs.cleaning_suggestions }}
+
+      # ===================== ERRORS =====================
+      - id: exclusivity_error
+        type: notify
+        level: error
+        message: "Track A and Track B are mutually exclusive. Upload either one flexible file OR all four structured files."
+
+      - id: missing_inputs_error
+        type: notify
+        level: warning
+        message: "Upload ALL FOUR files for Track A, or ONE flexible file for Track B."
+
+outputs:
+  - id: report_markdown
+    label: "Report"
+    type: markdown
+    from:
+      - "{{ steps.deliver_b.outputs.report_markdown }}"
+      - "{{ steps.deliver_a.outputs.report_markdown }}"
+
+  - id: normalized_csv
+    label: "Normalized Data (Track B)"
+    type: file
+    when: "{{ steps.deliver_b.outputs.normalized_csv is present }}"
+    from: "{{ steps.deliver_b.outputs.normalized_csv }}"
+
+  - id: data_notes
+    label: "Extraction Notes (Track B)"
+    type: text
+    when: "{{ steps.deliver_b.outputs.data_notes is present }}"
+    from: "{{ steps.deliver_b.outputs.data_notes }}"
+
+  - id: variance_table
+    label: "Variance Table (Track A)"
+    type: table
+    when: "{{ steps.deliver_a.outputs.variance_table is present }}"
+    from: "{{ steps.deliver_a.outputs.variance_table }}"
+
+  - id: audit_trail
+    label: "Audit Trail (Track A)"
+    type: text
+    when: "{{ steps.deliver_a.outputs.audit_trail is present }}"
+    from: "{{ steps.deliver_a.outputs.audit_trail }}"


### PR DESCRIPTION
## Summary
- add new `two-track-upload-report-v2.yaml` workflow spec
- new Track B sanitizes extracted data and returns normalized CSV, report markdown, and data notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b738ca8e00832ab8597dace0c4bc57