### PR TITLE
Add resilient two-track upload v3 workflow

### DIFF
--- a/two-track-upload-report-v3.yaml
+++ b/two-track-upload-report-v3.yaml
@@ -1,0 +1,274 @@
+name: two-track-upload-report-v3
+label: "Two-Track Upload → Report (resilient)"
+description: >
+  Track A (4 files) OR Track B (1 flexible file). Track B is chunked and page-filtered
+  to avoid timeouts and 502s. No invention: evidence-only.
+
+ui:
+  layout: vertical
+  sections:
+    - id: track_a
+      label: "Track A — Structured (4 files)"
+      inputs:
+        - { id: file_budget_actuals,  type: file, label: "Budget & Actuals",  accept: [".csv",".xlsx"] }
+        - { id: file_forecast,        type: file, label: "Forecast",          accept: [".csv",".xlsx"] }
+        - { id: file_master_metrics,  type: file, label: "Master Metrics",    accept: [".csv",".xlsx"] }
+        - { id: file_mapping,         type: file, label: "Mappings",          accept: [".csv",".xlsx"] }
+      helpers: [{ type: note, text: "Mutually exclusive with Track B." }]
+
+    - id: track_b
+      label: "Track B — Flexible (CSV/XLSX/PDF/DOC/TXT)"
+      inputs:
+        - { id: file_flexible, type: file, label: "Single Flexible Upload",
+            accept: [".csv",".xlsx",".xls",".pdf",".doc",".docx",".txt",".md",".json"] }
+      helpers: [{ type: note, text: "For incomplete or messy single files." }]
+
+    - id: run
+      inputs:
+        - id: generate
+          type: button
+          label: "Generate"
+          style: primary
+          on_click: { action: run-two-track-v3 }
+
+actions:
+  - id: run-two-track-v3
+    type: workflow
+    steps:
+      # --- exclusivity & routing ---
+      - id: exclusivity_check
+        type: branch
+        branches:
+          - when: >-
+              {{
+                inputs.file_flexible and
+                (inputs.file_budget_actuals or inputs.file_forecast or inputs.file_master_metrics or inputs.file_mapping)
+              }}
+            goto: exclusivity_error
+          - when: "{{ inputs.file_flexible }}"
+            goto: track_b_pipeline
+          - when: "{{ inputs.file_budget_actuals and inputs.file_forecast and inputs.file_master_metrics and inputs.file_mapping }}"
+            goto: track_a_pipeline
+          - else:
+            goto: missing_inputs_error
+
+      # ===================== TRACK B (resilient & chunked) =====================
+      - id: track_b_pipeline
+        type: subworkflow
+        steps:
+          # Quick meta so we can branch for large PDFs
+          - id: inspect
+            type: file_inspect
+            file: "{{ inputs.file_flexible }}"   # returns: mime, size_bytes, page_count (if PDF)
+
+          # If non-PDF or small PDF -> direct extract; else split & filter pages
+          - id: route_large
+            type: branch
+            branches:
+              - when: "{{ inspect.outputs.mime != 'application/pdf' or (inspect.outputs.page_count|default(0)) <= 12 }}"
+                goto: direct_extract
+              - else:
+                goto: split_and_filter
+
+          # ---- small or non-PDF path ----
+          - id: direct_extract
+            type: llm_extract
+            model: gpt-4o
+            timeout_sec: 90
+            retry: { max: 2, backoff_sec: 2 }
+            files: ["{{ inputs.file_flexible }}"]
+            prompt: |
+              ROLE: Finance data wrangler.
+              TASK: Extract ONLY real data to a CSV with columns (any true subset):
+                ["description","qty","unit","unit_price_sar","line_total_sar"].
+              Strip currency symbols/commas; no invented rows. Add brief NOTES.
+              OUTPUTS: normalized_csv, notes.
+
+          - id: direct_csv_clean
+            type: tabular_transform
+            code: |
+              T = READ_CSV(direct_extract.outputs.normalized_csv)
+              T = STRIP_WHITESPACE(T)
+              T = DROP_EMPTY_ROWS(T, keep_if_any_of=["description","qty","unit","unit_price_sar","line_total_sar"])
+              T = COERCE_NUMERIC(T, cols=[c for c in ["qty","unit_price_sar","line_total_sar"] if c in T.columns])
+              if ("line_total_sar" not in T.columns) and ("qty" in T.columns) and ("unit_price_sar" in T.columns):
+                  T["line_total_sar"] = SAFE_MUL(T["qty"], T["unit_price_sar"])
+              OUT = T
+
+          - id: direct_analyze
+            type: llm_analyze
+            model: gpt-4o
+            timeout_sec: 90
+            retry: { max: 2, backoff_sec: 2 }
+            inputs:
+              csv: "{{ steps.direct_csv_clean.outputs.OUT }}"
+              notes: "{{ steps.direct_extract.outputs.notes }}"
+            prompt: |
+              ROLE: Procurement/variance analyst. Evidence-only.
+              Use available numeric fields to compute totals and top lines.
+              List data gaps & assumptions. No invention.
+              OUTPUT: markdown report.
+
+          - id: deliver_direct
+            type: result
+            outputs:
+              report_markdown: "{{ steps.direct_analyze.outputs.text }}"
+              normalized_csv: "{{ steps.direct_csv_clean.outputs.OUT }}"
+              data_notes: "{{ steps.direct_extract.outputs.notes }}"
+
+          # ---- large PDF path: split -> score -> keep -> extract ----
+          - id: split_and_filter
+            type: document_split
+            file: "{{ inputs.file_flexible }}"
+            by: page
+            limit: 50             # safety cap
+            outputs: { pages: [] } # list of page files
+
+          - id: score_pages
+            type: llm_extract
+            model: gpt-4o-mini
+            timeout_sec: 60
+            retry: { max: 2, backoff_sec: 2 }
+            files: "{{ steps.split_and_filter.outputs.pages }}"
+            prompt: |
+              ROLE: Page screener.
+              For each page, output JSON with:
+                { "page": <index>, "keep": true|false, "reason": "…" }
+              keep=true iff the page contains a tabular structure or numeric item rows
+              (items/qty/unit/price/total). Exclude covers, signatures, terms, empty or noisy pages.
+              OUTPUT: keep_list (JSON array).
+
+          - id: select_pages
+            type: file_select
+            from: "{{ steps.split_and_filter.outputs.pages }}"
+            where: "{{ steps.score_pages.outputs.keep_list }}"  # selects only keep=true
+
+          - id: batch_extract
+            type: llm_extract
+            model: gpt-4o
+            timeout_sec: 90
+            retry: { max: 2, backoff_sec: 2 }
+            files: "{{ steps.select_pages.outputs.files }}"
+            prompt: |
+              ROLE: Finance data wrangler.
+              Merge rows from ALL provided pages into ONE CSV (UTF-8). Columns (subset):
+                ["description","qty","unit","unit_price_sar","line_total_sar"].
+              Normalize numbers; no invention; drop decorative lines.
+              OUTPUTS: normalized_csv, notes (include kept/ignored page indices).
+
+          - id: batch_clean
+            type: tabular_transform
+            code: |
+              T = READ_CSV(batch_extract.outputs.normalized_csv)
+              T = STRIP_WHITESPACE(T)
+              T = DROP_EMPTY_ROWS(T, keep_if_any_of=["description","qty","unit","unit_price_sar","line_total_sar"])
+              T = COERCE_NUMERIC(T, cols=[c for c in ["qty","unit_price_sar","line_total_sar"] if c in T.columns])
+              if ("line_total_sar" not in T.columns) and ("qty" in T.columns) and ("unit_price_sar" in T.columns):
+                  T["line_total_sar"] = SAFE_MUL(T["qty"], T["unit_price_sar"])
+              OUT = T
+
+          - id: batch_analyze
+            type: llm_analyze
+            model: gpt-4o
+            timeout_sec: 90
+            retry: { max: 2, backoff_sec: 2 }
+            inputs:
+              csv: "{{ steps.batch_clean.outputs.OUT }}"
+              notes: "{{ steps.batch_extract.outputs.notes }}"
+            prompt: |
+              ROLE: Procurement/variance analyst. Evidence-only.
+              Compute totals if amounts exist, else qualitative insights.
+              Include “Pages kept/ignored” from notes. No invention.
+              OUTPUT: markdown report.
+
+          - id: deliver_batch
+            type: result
+            outputs:
+              report_markdown: "{{ steps.batch_analyze.outputs.text }}"
+              normalized_csv: "{{ steps.batch_clean.outputs.OUT }}"
+              data_notes: "{{ steps.batch_extract.outputs.notes }}"
+
+      # ===================== TRACK A (same as before) =====================
+      - id: track_a_pipeline
+        type: subworkflow
+        steps:
+          - id: load_csvs
+            type: tabular_load
+            files:
+              - { id: budget_actuals, file: "{{ inputs.file_budget_actuals }}" }
+              - { id: forecast,       file: "{{ inputs.file_forecast }}" }
+              - { id: master_metrics, file: "{{ inputs.file_master_metrics }}" }
+              - { id: mapping,        file: "{{ inputs.file_mapping }}" }
+
+          - id: llm_harmonize_headers
+            type: llm_extract
+            model: gpt-4o
+            timeout_sec: 60
+            retry: { max: 2, backoff_sec: 2 }
+            files:
+              - "{{ inputs.file_budget_actuals }}"
+              - "{{ inputs.file_forecast }}"
+              - "{{ inputs.file_master_metrics }}"
+              - "{{ inputs.file_mapping }}"
+            prompt: |
+              Map headers to canonical (period, account, cost_center, amount, type, forecast_amount, currency).
+              Do not fabricate columns. Output header_mappings + notes.
+
+          - id: apply_header_mapping
+            type: tabular_transform
+            code: |
+              OUT_budget_actuals = APPLY_HEADERS(budget_actuals, llm_harmonize_headers.outputs.header_mappings['budget_actuals'])
+              OUT_forecast       = APPLY_HEADERS(forecast,       llm_harmonize_headers.outputs.header_mappings['forecast'])
+              OUT_master         = APPLY_HEADERS(master_metrics, llm_harmonize_headers.outputs.header_mappings['master_metrics'])
+              OUT_mapping        = APPLY_HEADERS(mapping,        llm_harmonize_headers.outputs.header_mappings['mapping'])
+
+          - id: compute_variance
+            type: tabular_transform
+            code: |
+              budget = FILTER(OUT_budget_actuals, type == "budget")
+              actual = FILTER(OUT_budget_actuals, type == "actual")
+              keys = ["period","account","cost_center"]
+              joined = JOIN(actual, budget, on=keys, how="inner", suffixes=("_actual","_budget"))
+              with_forecast = LEFT_JOIN(joined, OUT_forecast, on=keys)
+              OUT = with_forecast.assign(
+                variance_amount = if_present(amount_actual, amount_budget, amount_actual - amount_budget),
+                variance_pct    = if_present(amount_actual, amount_budget, safe_divide(amount_actual - amount_budget, NULLIFZERO(amount_budget)))
+              )
+
+          - id: summarize
+            type: llm_analyze
+            model: gpt-4o
+            timeout_sec: 60
+            retry: { max: 2, backoff_sec: 2 }
+            inputs: { table: "{{ steps.compute_variance.outputs.OUT }}" }
+            prompt: |
+              Evidence-only variance summary. No invention.
+
+          - id: deliver_a
+            type: result
+            outputs:
+              report_markdown: "{{ steps.summarize.outputs.text }}"
+              variance_table: "{{ steps.compute_variance.outputs.OUT }}"
+
+      # --- errors ---
+      - id: exclusivity_error
+        type: notify
+        level: error
+        message: "Track A and B are mutually exclusive. Upload either one flexible file OR all four structured files."
+      - id: missing_inputs_error
+        type: notify
+        level: warning
+        message: "Upload ALL FOUR files for Track A, or ONE flexible file for Track B."
+
+outputs:
+  - { id: report_markdown, label: "Report", type: markdown,
+      from: ["{{ steps.deliver_direct.outputs.report_markdown }}","{{ steps.deliver_batch.outputs.report_markdown }}","{{ steps.deliver_a.outputs.report_markdown }}"] }
+  - { id: normalized_csv, label: "Normalized Data (Track B)", type: file,
+      when: "{{ steps.deliver_direct.outputs.normalized_csv is present or steps.deliver_batch.outputs.normalized_csv is present }}",
+      from: "{{ steps.deliver_direct.outputs.normalized_csv or steps.deliver_batch.outputs.normalized_csv }}" }
+  - { id: data_notes, label: "Extraction Notes (Track B)", type: text,
+      when: "{{ steps.deliver_direct.outputs.data_notes is present or steps.deliver_batch.outputs.data_notes is present }}",
+      from: "{{ steps.deliver_direct.outputs.data_notes or steps.deliver_batch.outputs.data_notes }}" }
+  - { id: variance_table, label: "Variance Table (Track A)", type: table,
+      when: "{{ steps.deliver_a.outputs.variance_table is present }}",
+      from: "{{ steps.deliver_a.outputs.variance_table }}" }


### PR DESCRIPTION
## Summary
- add `two-track-upload-report-v3.yaml` with page-filtered, chunked Track B pipeline and existing Track A workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7407a7dd8832a930502e6d3075b03