### PR TITLE
Fix single-file workflow to generate drafts

### DIFF
--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -337,21 +337,55 @@
       }
       const f = $('fSingle').files[0];
       if (!f) { setStatus('Please choose a file.', 'err'); return; }
-      setStatus('Uploading…'); setBar(25); $('btnSingle').disabled=true;
-      const fd = new FormData(); fd.append('data_file', f);
-      const resp = await fetch('/upload', { method:'POST', body: fd });
+      setStatus('Processing…'); setBar(25); $('btnSingle').disabled = true;
+
+      // Step 1: extract tolerant rows from the uploaded file
+      const fd = new FormData(); fd.append('files', f);
+      const resp = await fetch('/extract/freeform', { method: 'POST', body: fd });
       if (!resp.ok) {
         const txt = await resp.text();
         setStatus('API error: ' + resp.status + ' ' + resp.statusText + '\n' + txt, 'err');
-        setBar(0); $('btnSingle').disabled=false; return;
+        setBar(0); $('btnSingle').disabled = false; return;
       }
-      const data = await resp.json();
-      setStatus('Done','ok'); setBar(100);
-      $('result').textContent = JSON.stringify(data,null,2);
+      const extracted = await resp.json();
+      const rows = extracted.rows || [];
+      if (!rows.length) {
+        setStatus('No valid rows found in file.', 'err');
+        setBar(0); $('btnSingle').disabled = false; return;
+      }
+
+      // Step 2: call the drafts endpoint with the extracted rows
+      const cfg = {
+        materiality_pct: Number($('materialityPct').value || 5),
+        materiality_amount_sar: Number($('materialityAmt').value || 100000),
+        bilingual: $('optBilingual').checked,
+        enforce_no_speculation: $('optNoSpec').checked,
+      };
+      setStatus('Calling API…'); setBar(60);
+      const payload = {
+        budget_actuals: [],
+        change_orders: rows,
+        vendor_map: [],
+        category_map: [],
+        config: cfg,
+      };
+      const resp2 = await fetch('/drafts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!resp2.ok) {
+        const txt = await resp2.text();
+        setStatus('API error: ' + resp2.status + ' ' + resp2.statusText + '\n' + txt, 'err');
+        setBar(0); $('btnSingle').disabled = false; return;
+      }
+      const result = await resp2.json();
+      setStatus('Done', 'ok'); setBar(100);
+      renderResult(result);
     } catch (err) {
       setStatus(String(err && err.message ? err.message : err), 'err'); setBar(0);
     } finally {
-      $('btnSingle').disabled=false; setTimeout(()=>setBar(0),1200);
+      $('btnSingle').disabled = false; setTimeout(() => setBar(0), 1200);
     }
   });
 


### PR DESCRIPTION
## Summary
- Generate drafts when using the Single Data File upload path
- Extract rows via `/extract/freeform` and feed them to `/drafts`

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b764b99cb0832ab90c3464f1ded3ed