### PR TITLE
feat: enrich procurement summary for single-file uploads

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -80,3 +80,17 @@ class ProcurementItem(BaseModel):
     evidence_link: str = "Uploaded procurement file"
     draft_en: str
     draft_ar: Optional[str] = None
+
+
+class VendorSnapshot(BaseModel):
+    """Aggregated vendor-level info for single-file uploads."""
+
+    vendor: str
+    quote_date: Optional[str] = None
+    validity_window: Optional[str] = None
+    delivery_lead_time: Optional[str] = None
+    payment_terms: Optional[str] = None
+    currency: Optional[str] = None
+    vat_rate: Optional[float] = None
+    total_excl_vat: Optional[float] = None
+    total_incl_vat: Optional[float] = None


### PR DESCRIPTION
## Summary
- expand procurement item model with vendor-level snapshot support
- parse additional item fields (quantity, pricing, VAT) from tabular inputs
- compute vendor snapshots, bid comparison grid, and best-mix savings in freeform upload endpoint
- guard LLM extraction so missing API keys don't crash single-file uploads

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `ruff check app tests`


------
https://chatgpt.com/codex/tasks/task_e_68b818d77d54832abd7c98863025419d