### PR TITLE
Add procurement summary cards for single-file uploads

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -153,3 +153,17 @@ def test_upload_llm_failure(monkeypatch):
     data = resp.json()
     assert data["count"] == 0
     assert data["procurement_summary"] == []
+
+
+def test_extract_freeform_procurement_summary():
+    client = TestClient(app)
+    file_content = b"co_id\nD01\nD02\n"
+    files = {"files": ("test.csv", file_content, "text/csv")}
+    resp = client.post("/extract/freeform", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 2
+    cards = data["procurement_summary"]
+    assert len(cards) == 2
+    assert all(c["evidence_link"] == "Uploaded procurement file" for c in cards)
+    assert all("draft_en" in c and "draft_ar" in c for c in cards)


### PR DESCRIPTION
## Summary
- Ensure procurement summary cards are generated for single-file uploads and freeform extraction.
- Include partially filled line items by relaxing row filtering and skipping only fully empty rows.
- Add test coverage for procurement summaries returned by the freeform extraction endpoint.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b826be367c832ab0f341acd9e23d8b