### PR TITLE
Expose item codes in procurement summary cards

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -238,7 +238,7 @@ def _build_procurement_summary(rows: List[Dict[str, Any]], bilingual: bool = Tru
             ar = " ".join(parts_ar).strip()
         out.append(
             ProcurementItem(
-                item_id=r.get("co_id") or r.get("linked_cost_code"),
+                item_code=r.get("co_id") or r.get("linked_cost_code"),
                 description=r.get("description"),
                 quantity=r.get("quantity"),
                 unit_price=r.get("unit_price"),
@@ -296,7 +296,7 @@ def _build_bid_comparison(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         min_vendor = min(vendor_prices, key=vendor_prices.get)
         amounts = list(vendor_prices.values())
         med = statistics.median(amounts) if amounts else None
-        row: Dict[str, Any] = {"item_id": item}
+        row: Dict[str, Any] = {"item_code": item}
         for vendor, amount in vendor_prices.items():
             variance_vs_median = amount - med if med is not None else None
             pct_spread = (
@@ -583,7 +583,7 @@ async def upload(
         total = sum(c.amount_sar or 0 for c in cards)
         item_table = [
             {
-                "item_id": r.get("co_id") or r.get("linked_cost_code"),
+                "item_code": r.get("co_id") or r.get("linked_cost_code"),
                 "description": r.get("description"),
                 "quantity": r.get("quantity"),
                 "unit_price": r.get("unit_price"),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -70,7 +70,7 @@ class DraftResponse(BaseModel):
 class ProcurementItem(BaseModel):
     """Lightweight summary card for single-file procurement uploads."""
 
-    item_id: Optional[str] = None
+    item_code: Optional[str] = None
     description: Optional[str] = None
     quantity: Optional[float] = None
     unit_price: Optional[float] = None

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -97,6 +97,7 @@ def test_upload_single_data_file():
     assert data["count"] == 2
     cards = data["procurement_summary"]
     assert any(c.get("description") for c in cards)
+    assert all("item_code" in c for c in cards)
 
 
 def test_upload_mutual_exclusive():
@@ -141,6 +142,7 @@ def test_pdf_fallback(monkeypatch):
     assert data["count"] == 2
     assert data["total_amount_sar"] == 300
     assert len(data["procurement_summary"]) == 2
+    assert all("item_code" in c for c in data["procurement_summary"])
 
 
 def test_upload_llm_failure(monkeypatch):
@@ -167,3 +169,4 @@ def test_extract_freeform_procurement_summary():
     assert len(cards) == 2
     assert all(c["evidence_link"] == "Uploaded procurement file" for c in cards)
     assert all("draft_en" in c and "draft_ar" in c for c in cards)
+    assert all("item_code" in c for c in cards)


### PR DESCRIPTION
## Summary
- Rename procurement summary field `item_id` to `item_code`
- Populate `item_code` in summary cards, bid comparison grid, and item table for single-file uploads
- Cover new field in upload tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b832ad7c68832a87fe08ea4873259f