### PR TITLE
Improve single-file variance handling

### DIFF
--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -305,6 +305,7 @@
   }
 
   window.__free_rows__ = [];
+  window.__free_mode__ = 'change_orders';
 
   async function doFreeformPreview() {
     const inp = document.getElementById('freeform_files');
@@ -312,8 +313,9 @@
     if (!inp.files.length) { box.style.display='block'; box.textContent='No files selected.'; return; }
     const out = await postFiles('/extract/freeform', inp.files);
     window.__free_rows__ = out.rows || [];
+    window.__free_mode__ = out.mode || 'change_orders';
     box.style.display='block';
-    box.textContent = JSON.stringify({rows: window.__free_rows__.slice(0,10), total: window.__free_rows__.length}, null, 2);
+    box.textContent = JSON.stringify({mode: window.__free_mode__, rows: window.__free_rows__.slice(0,10), total: window.__free_rows__.length}, null, 2);
   }
 
   async function doFreeformGenerate() {
@@ -322,6 +324,7 @@
     if (!window.__free_rows__.length && inp.files.length) {
       const out = await postFiles('/extract/freeform', inp.files);
       window.__free_rows__ = out.rows || [];
+      window.__free_mode__ = out.mode || 'change_orders';
     }
     const cfg = {
       materiality_pct: Number(el('mat_pct').value || 5),
@@ -330,8 +333,8 @@
       enforce_no_speculation: el('no_spec').checked,
     };
     const payload = {
-      budget_actuals: [],
-      change_orders: window.__free_rows__ || [],
+      budget_actuals: window.__free_mode__ === 'budget_actuals' ? window.__free_rows__ : [],
+      change_orders: window.__free_mode__ === 'change_orders' ? window.__free_rows__ : [],
       vendor_map: [],
       category_map: [],
       config: cfg,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -164,9 +164,26 @@ def test_extract_freeform_procurement_summary():
     resp = client.post("/extract/freeform", files=files)
     assert resp.status_code == 200
     data = resp.json()
+    assert data["mode"] == "change_orders"
     assert data["count"] == 2
     cards = data["procurement_summary"]
     assert len(cards) == 2
     assert all(c["evidence_link"] == "Uploaded procurement file" for c in cards)
     assert all("draft_en" in c and "draft_ar" in c for c in cards)
     assert all("item_code" in c for c in cards)
+
+
+def test_extract_freeform_budget_actuals():
+    client = TestClient(app)
+    file_content = (
+        b"project_id,period,cost_code,budget_sar,actual_sar\n"
+        b"P1,2024-01,CC1,100,120\n"
+        b"P1,2024-02,CC2,50,40\n"
+    )
+    files = {"files": ("ba.csv", file_content, "text/csv")}
+    resp = client.post("/extract/freeform", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "budget_actuals"
+    assert len(data["rows"]) == 2
+    assert data["count"] == 2


### PR DESCRIPTION
## Summary
- parse free-form uploads for budget vs actual columns
- surface data type via `mode` and generate drafts for budget uploads
- update UI and tests for new free-form detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8496fa7ac832a863b5947cb3428b8