### PR TITLE
Add single-file variance or summary processing

### DIFF
--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+import io, re, json
+from typing import List, Dict, Any, Optional, Tuple
+import pandas as pd
+import numpy as np
+import chardet
+
+try:
+    import pdfplumber
+except Exception:
+    pdfplumber = None
+try:
+    import docx
+except Exception:
+    docx = None
+
+# ----------------------------
+# Helpers (no speculation)
+# ----------------------------
+BUDGET_KEYS   = {"budget","planned","plan","budget_sar","planned_sar","budget_amount"}
+ACTUAL_KEYS   = {"actual","actuals","spent","actual_sar","actual_amount","spend_sar"}
+PROJECT_KEYS  = {"project","project_id","project name","projectname","proj_id"}
+PERIOD_KEYS   = {"period","month","month_year","posting_period","date"}
+CODE_KEYS     = {"cost_code","gl_code","costcode","account_code","code"}
+CAT_KEYS      = {"category","reporting_category","group"}
+DESC_KEYS     = {"description","desc","item","line_item","scope"}
+QTY_KEYS      = {"qty","quantity","qtty"}
+UPRICE_KEYS   = {"unit_price","unit price","rate","u.rate","unit_price_sar"}
+AMOUNT_KEYS   = {"amount","amount_sar","line_total","total","value","total_sar"}
+VENDOR_KEYS   = {"vendor","vendor_name","supplier","supplier_name","company"}
+
+AMT_RE = r'(?:SAR|SR|\$)?\s*([0-9]{1,3}(?:,[0-9]{3})*(?:\.[0-9]+)?|[0-9]+(?:\.[0-9]+)?)'
+DATE_RE = r'(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{4}[/-]\d{2}[/-]\d{2}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\s+\d{4})'
+ITEM_RE = r'\b(D0?\d+)\b'
+
+def _norm_cols(df: pd.DataFrame) -> Dict[str,str]:
+    m = {}
+    for c in df.columns:
+        k = str(c).strip().lower()
+        k = re.sub(r"[\u200B-\u200D\uFEFF]", "", k)
+        k = re.sub(r"[.\(\)\[\]]", " ", k)
+        k = re.sub(r"[-_]+", " ", k)
+        k = re.sub(r"\s+", " ", k).strip()
+        if k in m:  # keep first occurrence
+            continue
+        m[k] = c
+    return m
+
+def _read_df(name: str, data: bytes) -> pd.DataFrame:
+    low = name.lower()
+    if low.endswith(".xlsx") or low.endswith(".xls"):
+        try:
+            return pd.read_excel(io.BytesIO(data))
+        except Exception:
+            return pd.DataFrame()
+    enc = (chardet.detect(data) or {}).get("encoding") or "utf-8"
+    try:
+        return pd.read_csv(io.BytesIO(data), encoding=enc)
+    except Exception:
+        return pd.DataFrame()
+
+def _read_text(name: str, data: bytes) -> str:
+    low = name.lower()
+    if low.endswith(".pdf") and pdfplumber:
+        try:
+            texts = []
+            with pdfplumber.open(io.BytesIO(data)) as pdf:
+                for p in pdf.pages:
+                    texts.append(p.extract_text(x_tolerance=1.5, y_tolerance=3.0) or "")
+            return "\n".join(texts)
+        except Exception:
+            pass
+    if low.endswith(".docx") and docx:
+        try:
+            d = docx.Document(io.BytesIO(data))
+            return "\n".join(p.text for p in d.paragraphs)
+        except Exception:
+            pass
+    enc = (chardet.detect(data) or {}).get("encoding") or "utf-8"
+    try:
+        return data.decode(enc, errors="ignore")
+    except Exception:
+        return ""
+
+# ----------------------------
+# Budget/Actual detection
+# ----------------------------
+def _has_budget_actual(df: pd.DataFrame) -> bool:
+    if df.empty: return False
+    cols = _norm_cols(df)
+    has_b = any(k in cols for k in BUDGET_KEYS)
+    has_a = any(k in cols for k in ACTUAL_KEYS)
+    return bool(has_b and has_a)
+
+def extract_budget_variances(df: pd.DataFrame) -> List[Dict[str,Any]]:
+    if df.empty: return []
+    cols = _norm_cols(df)
+    get = lambda sset: next((cols[k] for k in sset if k in cols), None)
+
+    c_proj   = get(PROJECT_KEYS)
+    c_period = get(PERIOD_KEYS)
+    c_code   = get(CODE_KEYS)
+    c_cat    = get(CAT_KEYS)
+    c_bud    = get(BUDGET_KEYS)
+    c_act    = get(ACTUAL_KEYS)
+
+    if not (c_bud and c_act):
+        return []
+
+    out = []
+    for _, r in df.iterrows():
+        try:
+            bud = float(str(r[c_bud]).replace(",","").strip())
+            act = float(str(r[c_act]).replace(",","").strip())
+        except Exception:
+            continue
+        row = {
+            "project_id": (str(r[c_proj]).strip() if c_proj and pd.notna(r[c_proj]) else None),
+            "period":     (str(r[c_period]).strip() if c_period and pd.notna(r[c_period]) else None),
+            "cost_code":  (str(r[c_code]).strip() if c_code and pd.notna(r[c_code]) else None),
+            "category":   (str(r[c_cat]).strip()  if c_cat  and pd.notna(r[c_cat])  else None),
+            "budget_sar": bud,
+            "actual_sar": act,
+            "variance_sar": act - bud
+        }
+        out.append(row)
+    return out
+
+def extract_budget_actual_from_text(text: str) -> List[Dict[str,Any]]:
+    """
+    Look for paragraph blocks that contain both a 'budget' and an 'actual' amount.
+    Pairs are only created when both labels and amounts exist in the same block.
+    """
+    if not text.strip(): return []
+    blocks = re.split(r'\n\s*\n', text)
+    pairs: List[Dict[str,Any]] = []
+    for blk in blocks:
+        blk_clean = blk.strip()
+        if not blk_clean: continue
+        # Find amounts by label
+        mb = re.search(r'\b(budget|planned|plan)\b[^0-9\-+]*'+AMT_RE, blk_clean, re.I)
+        ma = re.search(r'\b(actual|spent)\b[^0-9\-+]*'+AMT_RE, blk_clean, re.I)
+        if mb and ma:
+            try:
+                bud = float(mb.group(2).replace(",",""))
+                act = float(ma.group(2).replace(",",""))
+            except Exception:
+                continue
+            # Derive a short description (first non-empty line)
+            first_line = next((ln.strip() for ln in blk_clean.splitlines() if ln.strip()), None)
+            pairs.append({
+                "project_id": None,
+                "period": None,
+                "cost_code": None,
+                "category": None,
+                "description": first_line[:200] if first_line else None,
+                "budget_sar": bud,
+                "actual_sar": act,
+                "variance_sar": act - bud
+            })
+    return pairs
+
+# ----------------------------
+# Procurement-like extraction (from table or text)
+# ----------------------------
+def _rows_from_table(df: pd.DataFrame) -> List[Dict[str,Any]]:
+    cols = _norm_cols(df)
+    get = lambda sset: next((cols[k] for k in sset if k in cols), None)
+    c_desc  = get(DESC_KEYS)
+    c_qty   = get(QTY_KEYS)
+    c_upr   = get(UPRICE_KEYS)
+    c_amt   = get(AMOUNT_KEYS)
+    c_code  = get(CODE_KEYS)
+    c_vend  = get(VENDOR_KEYS)
+    out: List[Dict[str,Any]] = []
+    for _, r in df.iterrows():
+        item = {
+            "item_code": str(r[c_code]).strip() if c_code and pd.notna(r[c_code]) else None,
+            "description": str(r[c_desc]).strip() if c_desc and pd.notna(r[c_desc]) else None,
+            "qty": None,
+            "unit_price_sar": None,
+            "amount_sar": None,
+            "vendor": str(r[c_vend]).strip() if c_vend and pd.notna(r[c_vend]) else None,
+            "doc_date": None,
+        }
+        if c_qty and pd.notna(r[c_qty]):
+            try: item["qty"] = float(str(r[c_qty]).replace(",",""))
+            except Exception: pass
+        if c_upr and pd.notna(r[c_upr]):
+            try: item["unit_price_sar"] = float(str(r[c_upr]).replace(",",""))
+            except Exception: pass
+        if c_amt and pd.notna(r[c_amt]):
+            try: item["amount_sar"] = float(str(r[c_amt]).replace(",",""))
+            except Exception: pass
+        if not any([item["description"], item["amount_sar"], item["unit_price_sar"], item["qty"]]):
+            continue
+        out.append(item)
+    return out
+
+def _rows_from_text_items(text: str) -> Tuple[List[Dict[str,Any]], Optional[str]]:
+    if not text.strip():
+        return [], None
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    rows: List[Dict[str,Any]] = []
+    doc_date = None
+    for ln in lines:
+        m = re.search(DATE_RE, ln, re.I)
+        if m: 
+            doc_date = m.group(1).strip()
+            break
+
+    curr: Dict[str,Any] = {}
+    buf: List[str] = []
+    def flush():
+        nonlocal curr, buf
+        if curr or buf:
+            desc = " ".join(buf).strip() or None
+            if desc and not curr.get("description"):
+                curr["description"] = desc[:500]
+            if any([curr.get("description"), curr.get("amount_sar"), curr.get("unit_price_sar"), curr.get("qty")]):
+                rows.append(curr)
+        curr, buf = {}, []
+
+    for ln in lines:
+        code = re.search(ITEM_RE, ln, re.I)
+        if code:
+            flush()
+            curr = {"item_code": code.group(1), "description": None, "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor": None, "doc_date": doc_date}
+            buf = [ln]
+            mq = re.search(r'\bQty[: ]+([0-9]+)', ln, re.I) or re.search(r'\b([0-9]+)\s*(?:pcs|sets|qty)\b', ln, re.I)
+            if mq: curr["qty"] = float(mq.group(1))
+            mu = re.search(r'(?:Unit Price|Rate|U\.??\s*Rate).{0,10}'+AMT_RE, ln, re.I)
+            if mu: 
+                try: curr["unit_price_sar"] = float(mu.group(1).replace(",",""))
+                except: pass
+            mt = re.search(r'(?:Line\s*Total|Total|Amount).{0,10}'+AMT_RE, ln, re.I)
+            if mt:
+                try: curr["amount_sar"] = float(mt.group(1).replace(",",""))
+                except: pass
+            continue
+        if curr:
+            buf.append(ln)
+            if curr.get("qty") is None:
+                mq = re.search(r'\bQty[: ]+([0-9]+)', ln, re.I) or re.search(r'\b([0-9]+)\s*(?:pcs|sets|qty)\b', ln, re.I)
+                if mq: curr["qty"] = float(mq.group(1))
+            if curr.get("unit_price_sar") is None:
+                mu = re.search(r'(?:Unit Price|Rate|U\.??\s*Rate).{0,12}'+AMT_RE, ln, re.I)
+                if mu:
+                    try: curr["unit_price_sar"] = float(mu.group(1).replace(",",""))
+                    except: pass
+            if curr.get("amount_sar") is None:
+                mt = re.search(r'(?:Line\s*Total|Total|Amount).{0,12}'+AMT_RE, ln, re.I)
+                if mt:
+                    try: curr["amount_sar"] = float(mt.group(1).replace(",",""))
+                    except: pass
+    flush()
+    for it in rows:
+        if it.get("amount_sar") is None and it.get("qty") is not None and it.get("unit_price_sar") is not None:
+            it["amount_sar"] = round(it["qty"] * it["unit_price_sar"], 2)
+        it.setdefault("doc_date", doc_date)
+    return rows, doc_date
+
+# ----------------------------
+# Insights (no speculation; computed from extracted rows)
+# ----------------------------
+def build_variance_insights(rows: List[Dict[str,Any]]) -> Dict[str,Any]:
+    if not rows: return {"total_budget":0,"total_actual":0,"total_variance":0,"top_increases":[],"top_decreases":[]}
+    # sums
+    tb = sum(r.get("budget_sar",0) for r in rows if isinstance(r.get("budget_sar"), (int,float)))
+    ta = sum(r.get("actual_sar",0) for r in rows if isinstance(r.get("actual_sar"), (int,float)))
+    tv = ta - tb
+    # sort by abs variance
+    ranked = []
+    for r in rows:
+        b = r.get("budget_sar"); a = r.get("actual_sar")
+        if isinstance(b,(int,float)) and isinstance(a,(int,float)):
+            ranked.append({**r,"variance_sar":a-b})
+    ranked.sort(key=lambda x: abs(x["variance_sar"]), reverse=True)
+    top_inc = [x for x in ranked if x["variance_sar"]>0][:5]
+    top_dec = [x for x in ranked if x["variance_sar"]<0][:5]
+    return {"total_budget":tb,"total_actual":ta,"total_variance":tv,"top_increases":top_inc,"top_decreases":top_dec}
+
+# ----------------------------
+# Orchestrator
+# ----------------------------
+def process_single_file(name: str, data: bytes) -> Dict[str,Any]:
+    """
+    Returns:
+      {"mode":"variance","variances":[...], "insights": {...}}
+      OR
+      {"mode":"summary","items":[...]}  # procurement/general summary
+    """
+    # 1) Try table route
+    df = _read_df(name, data)
+    if not df.empty and _has_budget_actual(df):
+        variances = extract_budget_variances(df)
+        return {"mode":"variance", "variances": variances, "insights": build_variance_insights(variances)}
+
+    # 2) Try text route for budget/actual
+    text = _read_text(name, data)
+    pairs = extract_budget_actual_from_text(text)
+    if pairs:
+        return {"mode":"variance", "variances": pairs, "insights": build_variance_insights(pairs)}
+
+    # 3) No budget/actual → procurement/general summary
+    items: List[Dict[str,Any]] = []
+    if not df.empty:
+        items = _rows_from_table(df)
+    if not items and text:
+        items, _ = _rows_from_text_items(text)
+
+    filtered = [it for it in items if any([it.get("description"), it.get("amount_sar"), it.get("unit_price_sar"), it.get("qty")])]
+    return {"mode":"summary", "items": filtered}
+
+def draft_bilingual_procurement_card(it: Dict[str,Any], file_label: str) -> Dict[str,str]:
+    parts_en = []
+    code = it.get("item_code"); desc = it.get("description"); qty = it.get("qty")
+    upr  = it.get("unit_price_sar"); amt = it.get("amount_sar"); ven = it.get("vendor"); dt = it.get("doc_date")
+    if code: parts_en.append(f"Item: {code}")
+    if desc: parts_en.append(f"Description: {desc}")
+    if qty is not None: parts_en.append(f"Quantity: {qty}")
+    if upr is not None: parts_en.append(f"Unit price (SAR): {upr}")
+    if amt is not None: parts_en.append(f"Line total (SAR): {amt}")
+    if ven: parts_en.append(f"Vendor: {ven}")
+    if dt:  parts_en.append(f"Document date: {dt}")
+    parts_en.append(f"Evidence: {file_label}")
+
+    parts_ar = []
+    if code: parts_ar.append(f"البند: {code}")
+    if desc: parts_ar.append(f"الوصف: {desc}")
+    if qty is not None: parts_ar.append(f"الكمية: {qty}")
+    if upr is not None: parts_ar.append(f"سعر الوحدة (ريال): {upr}")
+    if amt is not None: parts_ar.append(f"الإجمالي (ريال): {amt}")
+    if ven: parts_ar.append(f"المورد: {ven}")
+    if dt:  parts_ar.append(f"تاريخ المستند: {dt}")
+    parts_ar.append(f"الدليل: {file_label}")
+
+    return {"en": " | ".join(parts_en), "ar": " | ".join(parts_ar)}
+

--- a/app/static/ceo.html
+++ b/app/static/ceo.html
@@ -36,6 +36,16 @@
   <h3>Result</h3>
   <pre id="resultArea">{}</pre>
 </div>
+
+<div class="card" style="margin-top:20px;">
+  <h3>Single Data File</h3>
+  <p>Upload a single procurement or report file. If both Budget and Actual are found, variances will be calculated; otherwise a procurement/general summary is produced.</p>
+  <input id="single_file" type="file" accept=".csv,.xlsx,.xls,.docx,.pdf,.txt,.md,.rtf" />
+  <div style="margin-top:10px;">
+    <button onclick="onSingleProcess()">Process file</button>
+  </div>
+  <div id="single_result" style="margin-top:10px;"></div>
+</div>
 <script>
 const ui = {
   btn: document.getElementById('generateBtn'),
@@ -108,5 +118,115 @@ ui.btn.onclick = async () => {
     ui.btn.disabled = false;
   }
 };
+
+const esc = (s) => (s == null ? '' : String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])));
+
+async function postSingleFile(url, file) {
+  const fd = new FormData();
+  fd.append('file', file);
+  const res = await fetch(url, { method: 'POST', body: fd });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+function renderProcurementSummary(items, drafts) {
+  const host = document.getElementById("single_result");
+  if (!items || !items.length) {
+    host.innerHTML = `<div class="warn">No extractable items found in the file.</div>`;
+    return;
+  }
+  let html = `<h4>Procurement / General Summary</h4>`;
+  for (let i=0;i<items.length;i++) {
+    const it = items[i] || {};
+    const d  = (drafts && drafts[i]) || {};
+    html += `
+      <div class="card" style="margin:10px 0;">
+        <div style="font-weight:600;margin-bottom:4px;">Item ${i+1}</div>
+        <div style="font-size:14px;opacity:.85">
+          ${it.item_code ? `<div>Item code: ${esc(it.item_code)}</div>` : ``}
+          ${it.description ? `<div>Description: ${esc(it.description)}</div>` : ``}
+          ${it.qty != null ? `<div>Quantity: ${esc(it.qty)}</div>` : ``}
+          ${it.unit_price_sar != null ? `<div>Unit price (SAR): ${esc(it.unit_price_sar)}</div>` : ``}
+          ${it.amount_sar != null ? `<div>Line total (SAR): ${esc(it.amount_sar)}</div>` : ``}
+          ${it.vendor ? `<div>Vendor: ${esc(it.vendor)}</div>` : ``}
+          ${it.doc_date ? `<div>Document date: ${esc(it.doc_date)}</div>` : ``}
+          <div>Evidence: Uploaded procurement file</div>
+        </div>
+        <div style="margin-top:8px;">
+          <div><strong>Draft (EN):</strong> ${esc(d.en || "")}</div>
+          <div><strong>المسودة (AR):</strong> ${esc(d.ar || "")}</div>
+        </div>
+      </div>
+    `;
+  }
+  host.innerHTML = html;
+}
+
+function renderVarianceInsights(resp) {
+  const host = document.getElementById("single_result");
+  const v = resp.variances || [];
+  const ins = resp.insights || {};
+  let html = `<h4>Variance Insights</h4>
+    <div class="card" style="margin:10px 0;padding:8px 10px;font-size:14px;">
+      <div>Total Budget (SAR): <b>${esc(ins.total_budget)}</b></div>
+      <div>Total Actual (SAR): <b>${esc(ins.total_actual)}</b></div>
+      <div>Total Variance (SAR): <b>${esc(ins.total_variance)}</b></div>
+    </div>
+    <table style="width:100%;border-collapse:collapse;margin-top:6px;">
+      <thead><tr>
+        <th style="text-align:left">Project</th>
+        <th style="text-align:left">Period</th>
+        <th style="text-align:left">Cost Code</th>
+        <th style="text-align:left">Description</th>
+        <th style="text-align:right">Budget</th>
+        <th style="text-align:right">Actual</th>
+        <th style="text-align:right">Variance</th>
+      </tr></thead><tbody>`;
+  for (const r of v) {
+    html += `<tr>
+      <td>${esc(r.project_id||"")}</td>
+      <td>${esc(r.period||"")}</td>
+      <td>${esc(r.cost_code||"")}</td>
+      <td>${esc(r.description||"")}</td>
+      <td style="text-align:right">${esc(r.budget_sar)}</td>
+      <td style="text-align:right">${esc(r.actual_sar)}</td>
+      <td style="text-align:right">${esc(r.variance_sar)}</td>
+    </tr>`;
+  }
+  html += `</tbody></table>`;
+
+  const inc = (ins.top_increases||[]).slice(0,5);
+  const dec = (ins.top_decreases||[]).slice(0,5);
+  if (inc.length || dec.length) {
+    html += `<div style="display:flex;gap:16px;margin-top:12px;flex-wrap:wrap;">
+      <div class="card" style="flex:1;min-width:260px;"><h5>Top Increases</h5>${
+        inc.map(x=>`<div>${esc(x.cost_code||x.description||"")} — <b>${esc(x.variance_sar)}</b></div>`).join("")||"<div>—</div>"}</div>
+      <div class="card" style="flex:1;min-width:260px;"><h5>Top Decreases</h5>${
+        dec.map(x=>`<div>${esc(x.cost_code||x.description||"")} — <b>${esc(x.variance_sar)}</b></div>`).join("")||"<div>—</div>"}</div>
+    </div>`;
+  }
+  host.innerHTML = html;
+}
+
+async function onSingleProcess() {
+  const input = document.getElementById("single_file");
+  const host  = document.getElementById("single_result");
+  if (!input.files || input.files.length === 0) {
+    host.textContent = "Please choose a file.";
+    return;
+  }
+  host.textContent = "Processing…";
+  try {
+    const res = await postSingleFile("/singlefile/report", input.files[0]);
+    if (res.mode === "variance") {
+      renderVarianceInsights(res);
+    } else {
+      renderProcurementSummary(res.items || [], res.drafts || []);
+    }
+  } catch (e) {
+    host.textContent = "Failed to process file. Check server logs.";
+    console.error(e);
+  }
+}
 </script>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.116.1
 uvicorn==0.35.0
 pydantic==2.11.7
 openai==1.102.0
-pandas==2.2.2
+pandas>=2.1.0
 python-multipart==0.0.9
 requests>=2.31
 pytest==8.4.1
@@ -11,5 +11,6 @@ mypy==1.17.1
 openpyxl==3.1.5
 pdfplumber>=0.11.0
 pdfminer.six
-python-docx
-chardet
+python-docx>=1.1.2
+chardet>=5.2.0
+numpy>=1.26.0


### PR DESCRIPTION
## Summary
- support parsing single uploaded file to compute budget vs actual variances or produce procurement/general summaries
- expose `/singlefile/report` API endpoint and front-end rendering for variance insights or summary cards
- add dependencies for PDF/Word/text extraction and numeric processing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b863a4ce08832a8bcf0c48cf323245