### PR TITLE
Single-file intake: variance when possible, Procurement Summary otherwise (PDF/Word/CSV/Excel/Text)

### DIFF
--- a/app/parsers/procurement_pdf.py
+++ b/app/parsers/procurement_pdf.py
@@ -1,0 +1,85 @@
+from typing import List, Dict, Any
+import io
+from pdfminer.high_level import extract_text
+import re
+
+RE_DATE = re.compile(r'\b(?:\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|(?:\d{4}-\d{2}-\d{2}))\b')
+RE_ITEM = re.compile(r'\b(D0?\d|Item\s*No\.?\s*:?\s*\d+)\b', re.I)
+RE_QTY = re.compile(r'\b(?:QTY|Quantity)\s*[:=]?\s*(\d+(?:\.\d+)?)', re.I)
+RE_PRICE = re.compile(r'\b(?:Unit\s*Price|U\.?\s*Rate|Price)\s*(?:in\s*SAR)?\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
+RE_TOTAL = re.compile(r'\b(?:TOTAL|Amount|Grand\s*Total)\s*(?:in\s*SAR)?\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
+RE_VENDOR = re.compile(r'\b(?:Admark Creative|AL AZAL|Al Azal|Modern Furnishing|Woodwork Arts|Burj|OAKTREE|Oaktree|Alam)\b.*', re.I)
+
+
+def _num(s: str) -> float | None:
+    if not s:
+        return None
+    s = s.replace(',', '').replace('SAR', '').strip()
+    try:
+        return float(s)
+    except:  # noqa: E722
+        return None
+
+
+def parse_procurement_pdf(pdf_bytes: bytes) -> Dict[str, Any]:
+    """
+    Extract line items without inventing anything.
+    Returns {"items":[{item_code, description, qty, unit_price_sar, amount_sar, vendor_name, doc_date}], "meta":{...}}
+    Missing fields stay None.
+    """
+    text = extract_text(io.BytesIO(pdf_bytes)) or ""
+    # Doc date / vendor (best-effort, no invention)
+    date = None
+    m = RE_DATE.search(text)
+    if m:
+        date = m.group(0)
+
+    vendor = None
+    vm = RE_VENDOR.search(text)
+    if vm:
+        vendor = vm.group(0).strip()
+
+    # Split into blocks around item markers to keep descriptions intact
+    chunks = re.split(r'(?=(?:^|\n).{0,10}(?:D0?\d\b|Item\s*No\.?\s*:?\s*\d+))', text, flags=re.I)
+    items: List[Dict[str, Any]] = []
+
+    for ch in chunks:
+        if not RE_ITEM.search(ch):
+            continue
+        code_m = RE_ITEM.search(ch)
+        item_code = code_m.group(1).strip() if code_m else None
+
+        # description: take the paragraph following the code line
+        # keep only what exists in the PDF (truncate excessive whitespace)
+        desc_lines = [ln.strip() for ln in ch.splitlines() if ln.strip()]
+        description = " ".join(desc_lines[:20])[:2000] if desc_lines else None
+
+        qty = None
+        q = RE_QTY.search(ch)
+        if q:
+            qty = _num(q.group(1))
+
+        unit_price = None
+        up = RE_PRICE.search(ch)
+        if up:
+            unit_price = _num(up.group(1))
+
+        amount = None
+        tm = RE_TOTAL.search(ch)
+        if tm:
+            amount = _num(tm.group(1))
+        elif qty and unit_price:
+            amount = round(qty * unit_price, 2)
+
+        items.append({
+            "item_code": item_code,
+            "description": description,
+            "qty": qty,
+            "unit_price_sar": unit_price,
+            "amount_sar": amount,
+            "vendor_name": vendor,
+            "doc_date": date,
+            "source": "uploaded_file",
+        })
+
+    return {"items": items, "meta": {"vendor_name": vendor, "doc_date": date}}

--- a/app/parsers/single_file_intake.py
+++ b/app/parsers/single_file_intake.py
@@ -1,0 +1,85 @@
+from typing import Dict, Any, List
+import io
+import pandas as pd
+from docx import Document
+from .procurement_pdf import parse_procurement_pdf
+
+# Column synonym maps for tolerant CSV/Excel intake
+MAP = {
+  "budget": {"budget","budget_sar","planned","plan","budget_value","planned_sar"},
+  "actual": {"actual","actuals","spent","spend","actual_sar","cost_to_date","ctd"},
+  "project_id": {"project","project_id","job","job_id","project name"},
+  "period": {"period","month","date"},
+  "cost_code": {"cost_code","code","account","gl","linked_cost_code"},
+  "category": {"category","cat","trade"}
+}
+
+def _map_cols(df: pd.DataFrame) -> pd.DataFrame:
+  lower = {c: c.strip().lower() for c in df.columns}
+  rename = {}
+  inv = {k: set(v) for k,v in MAP.items()}
+  for std, alts in inv.items():
+    for col, low in lower.items():
+      if low in alts and std not in df.columns:
+        rename[col] = std
+  if rename:
+    df = df.rename(columns=rename)
+  return df
+
+def _has_budget_actual(df: pd.DataFrame) -> bool:
+  cols = {c.lower() for c in df.columns}
+  return bool(MAP["budget"] & cols) and bool(MAP["actual"] & cols)
+
+def parse_single_file(filename: str, data: bytes) -> Dict[str, Any]:
+  name = (filename or "").lower()
+  # PDF
+  if name.endswith(".pdf"):
+    return {"procurement_summary": parse_procurement_pdf(data)}
+  # Word
+  if name.endswith(".docx"):
+    doc = Document(io.BytesIO(data))
+    text = "\n".join(p.text for p in doc.paragraphs)
+    return {"procurement_summary": {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}}
+  # CSV/Excel -> try variance; if not possible, summarize rows
+  if name.endswith(".csv"):
+    df = pd.read_csv(io.BytesIO(data))
+  elif name.endswith(".xlsx") or name.endswith(".xls"):
+    df = pd.read_excel(io.BytesIO(data))
+  else:
+    # plain text fallback
+    text = data.decode("utf-8", errors="ignore")
+    return {"procurement_summary": {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}}
+
+  df = _map_cols(df)
+  if _has_budget_actual(df):
+    # minimal variance calc; UI will render nicely
+    df["variance_sar"] = df.filter(like="actual", axis=1).iloc[:,0] - df.filter(like="budget", axis=1).iloc[:,0]
+    bud = df.filter(like="budget", axis=1).iloc[:,0].abs().replace(0, pd.NA)
+    df["variance_pct"] = (df["variance_sar"] / bud * 100).round(2)
+    records = []
+    for _, r in df.iterrows():
+      records.append({
+        "variance": {
+          "project_id": r.get("project_id"),
+          "period": str(r.get("period")),
+          "category": r.get("category"),
+          "budget_sar": float(r.filter(like="budget").iloc[0]) if r.filter(like="budget").size else None,
+          "actual_sar": float(r.filter(like="actual").iloc[0]) if r.filter(like="actual").size else None,
+          "variance_sar": float(r.get("variance_sar")) if pd.notna(r.get("variance_sar")) else None,
+          "variance_pct": float(r.get("variance_pct")) if pd.notna(r.get("variance_pct")) else None,
+          "drivers": [],
+          "vendors": [],
+          "evidence_links": []
+        },
+        "draft_en": None,
+        "draft_ar": None,
+        "analyst_notes": None
+      })
+    return {"variance_items": records}
+  else:
+    # not a variance file → list first 50 rows as procurement-like lines (no invention)
+    items: List[Dict[str,Any]] = []
+    for _, r in df.head(50).iterrows():
+      desc = " ".join(str(v) for v in r.to_dict().values() if pd.notna(v))[:2000]
+      items.append({"item_code": None, "description": desc, "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"})
+    return {"procurement_summary": {"items": items, "meta": {}}}

--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -88,10 +88,11 @@
 <!-- Single Data File (CSV, Excel, Word, PDF, or Text) -->
 <div class="group">
   <label class="lbl">Single Data File (CSV, Excel, Word, PDF, or Text)</label>
-  <input id="single_file" type="file" accept=".csv,.xlsx,.xls,.docx,.pdf,.txt" />
-  <label><input id="opt_bilingual" type="checkbox" checked /> Bilingual</label>
-  <button id="btn_single_generate" class="btn primary">Generate from file</button>
-  <div id="single_results" class="results"></div>
+  <input id="single-file-input" type="file" accept=".csv,.xlsx,.xls,.docx,.pdf,.txt" />
+  <label><input id="opt-bilingual" type="checkbox" checked /> Bilingual</label>
+  <label><input id="opt-nospec" type="checkbox" checked /> No speculation</label>
+  <!-- hook:single-file-generate-button -->
+  <button class="btn" onclick="generateFromSingleFile()">Generate from file</button>
 </div>
 
 <div class="bar"><div class="fill" id="bar"></div></div>
@@ -362,44 +363,60 @@
   });
 </script>
 
-<!-- Single-file track: update button target and render modes -->
+<!-- Single file card renderer -->
 <script>
-  async function generateFromSingle() {
-    const file = document.getElementById('single_file').files[0];
-    if (!file) { toast('Please choose a file'); return; }
+  async function generateFromSingleFile() {
     const fd = new FormData();
-    fd.append('file', file);
-    fd.append('bilingual', document.getElementById('opt_bilingual').checked ? 'true' : 'false');
-    const resp = await fetch('/single/generate', { method:'POST', body: fd });
-    const data = await resp.json();
-    const out = document.getElementById('single_results');
-    out.innerHTML = '';
-    if (data.mode === 'variance') {
-      out.innerHTML = `<div class="hint">Detected budget vs actual. Showing quick variance items.</div>` +
-        data.items.map(it => `
-          <div class="card">
-            <div class="row">
-              <b>${it.project_id || 'Item'}</b>
-              <span>Budget: SAR ${it.budget_sar.toLocaleString()}</span>
-              <span>Actual: SAR ${it.actual_sar.toLocaleString()}</span>
-              <span>Variance: SAR ${it.variance_sar.toLocaleString()} (${(it.variance_pct??0).toFixed(2)}%)</span>
-            </div>
-          </div>`).join('');
-    } else if (data.mode === 'procurement') {
-      out.innerHTML = `<h3>Procurement Summary</h3>` +
-        data.cards.map(c => `
-          <div class="card">
-            <div class="row"><b>${c.title}</b></div>
-            <div class="row">${c.body_en}</div>
-            ${c.body_ar ? `<div class="row muted">${c.body_ar}</div>` : ''}
-            <div class="row tiny muted">${c.source}</div>
-          </div>`).join('');
-    } else {
-      out.innerHTML = `<div class="card"><pre>${(data.text||'').replaceAll('<','&lt;')}</pre></div>`;
+    const f = document.querySelector('#single-file-input').files[0];
+    if (!f) { toast('Please choose a file'); return; }
+    fd.append('file', f);
+    fd.append('bilingual', document.querySelector('#opt-bilingual').checked ? 'true' : 'false');
+    fd.append('no_speculation', document.querySelector('#opt-nospec').checked ? 'true' : 'false');
+
+    setStatus('Calling model…');
+    try {
+      const res = await fetch('/drafts/from-file', { method:'POST', body: fd });
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      clearReport();
+
+      if (data.procurement_summary && data.procurement_summary.items && data.procurement_summary.items.length) {
+        renderProcurementSummary(data.procurement_summary);
+        setStatus('Done');
+        return;
+      }
+      if (data.variance_items && data.variance_items.length) {
+        renderVarianceList(data.variance_items);
+        setStatus('Done');
+        return;
+      }
+      setStatus('No variance items found.');
+    } catch (e) {
+      setStatus('Load failed');
+      showError(e.message || e.toString());
     }
   }
-  // wire the single button
-  document.getElementById('btn_single_generate').onclick = generateFromSingle;
+
+  function renderProcurementSummary(ps) {
+    const root = ensureSection('report-root', 'Procurement Summary');
+    ps.items.forEach((it, idx) => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.innerHTML = `
+        <div class="row">
+          <div><b>Item</b>: ${it.item_code ?? '—'}</div>
+          <div><b>Qty</b>: ${it.qty ?? '—'}</div>
+          <div><b>Unit price (SAR)</b>: ${it.unit_price_sar ?? '—'}</div>
+          <div><b>Amount (SAR)</b>: ${it.amount_sar ?? '—'}</div>
+          <div><b>Vendor</b>: ${it.vendor_name ?? '—'}</div>
+          <div><b>Doc date</b>: ${it.doc_date ?? '—'}</div>
+        </div>
+        <div class="desc">${escapeHtml(it.description || '')}</div>
+        <div class="evidence"><i>Source: Uploaded procurement file</i></div>
+      `;
+      root.appendChild(card);
+    });
+  }
 </script>
 
 <style>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ openai==1.102.0
 pandas>=2.1.0
 pdfplumber==0.11.4
 pypdf==4.2.0
-python-docx==1.1.2
+python-docx>=1.1.0
 openpyxl==3.1.5
 chardet==5.2.0
 python-multipart==0.0.9
@@ -14,4 +14,4 @@ pytest==8.4.1
 ruff==0.12.10
 mypy==1.17.1
 numpy>=1.26.0
-pdfminer.six
+pdfminer.six>=20231228


### PR DESCRIPTION
## Summary
- add parser for procurement PDFs
- support single-file variance or procurement summary intake
- expose `/drafts/from-file` endpoint and UI hook

## Testing
- `ruff check app/parsers/procurement_pdf.py app/parsers/single_file_intake.py app/main.py`
- `mypy app/parsers/procurement_pdf.py app/parsers/single_file_intake.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b88227ba80832a8ddd04304284254d