### PR TITLE
feat: use strict single-file analyzer

### DIFF
--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -4,31 +4,17 @@ function generateFromSingleFile() {
   if (!file) return;
   const fd = new FormData();
   fd.append('file', file);
-  fetch('/singlefile/generate-async', { method: 'POST', body: fd })
+  fetch('/singlefile/analyze', { method: 'POST', body: fd })
     .then(r => r.json().then(j => ({ ok: r.ok, body: j })))
     .then(({ ok, body }) => {
-      if (!ok || !body.ok) { showError(body.error || 'upload_failed'); return; }
-      const jobId = body.job_id;
-      const t0 = Date.now();
-      const poll = () => {
-        fetch(`/jobs/${jobId}`)
-          .then(r => r.json())
-          .then(jr => {
-            const d = document.getElementById('diag-body');
-            if (d) { d.textContent = JSON.stringify(jr, null, 2); document.getElementById('diag').open = true; }
-            if (jr.status === 'done' && jr.ok) {
-              showResultJSON(jr.payload || {});
-            } else if (jr.status === 'error') {
-              showError(`${jr.stage}: ${jr.error}`);
-            } else if (Date.now() - t0 < 210000) {
-              setTimeout(poll, 1500);
-            } else {
-              showError('processing_timeout');
-            }
-          })
-          .catch(e => showError(e));
-      };
-      poll();
+      if (!ok) { showError(body.error || 'upload_failed'); return; }
+      if (body.report_type === 'procurement_summary') {
+        renderProcurementCards(body);
+      } else if (body.report_type === 'variance_insights') {
+        renderVarianceInsights(body);
+      } else {
+        showResultJSON(body);
+      }
     })
     .catch(e => showError(e));
 }


### PR DESCRIPTION
## Summary
- switch single-file UI to `/singlefile/analyze`
- render procurement cards or variance insights from analyzer results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8aeff0b90832a94a014d77782ab95