### PR TITLE
Add robust single-file router with graceful error handling

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, UploadFile, File
+from app.parsers.procurement_pdf import parse_procurement_pdf
+from app.services.singlefile import process_single_file
+
+router = APIRouter()
+
+@router.post("/drafts/from-file")
+async def from_file(file: UploadFile = File(...)):
+    try:
+        data = await file.read()
+        is_pdf = file.filename.lower().endswith(".pdf")
+        if is_pdf:
+            result = parse_procurement_pdf(data)
+            payload = {"procurement_summary": {"items": result.get("items", [])}, "meta": result.get("meta", {})}
+        else:
+            payload = process_single_file(file.filename, data)
+        return payload
+    except Exception as e:
+        # Never bubble up to a 502 — surface as a structured response the UI can display.
+        return {"error": f"single-file parse failed: {type(e).__name__}: {e}"}


### PR DESCRIPTION
## Summary
- add new `/drafts/from-file` router to parse procurement PDFs or other single files
- wrap parsing in try/except to return structured error instead of 502

## Testing
- `ruff check app/routers/drafts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8bb1962c8832a83b17ba435d7b8e5