### PR TITLE
Improve single-file processing for variance vs procurement

### DIFF
--- a/app/services/insights.py
+++ b/app/services/insights.py
@@ -1,0 +1,66 @@
+from typing import List, Dict, Any
+
+
+def _num(x):
+    try:
+        return float(str(x).replace(",", "").strip())
+    except Exception:
+        return None
+
+
+def compute_procurement_insights(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize procurement lines for more meaningful single-file output."""
+    per_vendor: Dict[str, float] = {}
+    per_item_stats: Dict[str, Dict[str, float]] = {}
+    top_lines: List[Dict[str, Any]] = []
+
+    for it in items:
+        vendor = (it.get("vendor_name") or "").strip() or "Unknown vendor"
+        qty = _num(it.get("qty")) or 0
+        unit = _num(it.get("unit_price_sar")) or 0
+        amt = _num(it.get("amount_sar")) or (qty * unit)
+        code = (it.get("item_code") or "").strip() or "-"
+
+        per_vendor[vendor] = per_vendor.get(vendor, 0.0) + (amt or 0.0)
+
+        stats = per_item_stats.setdefault(
+            code, {"min_unit": None, "max_unit": None, "sum_unit": 0.0, "count": 0}
+        )
+        if unit:
+            stats["min_unit"] = unit if stats["min_unit"] is None else min(stats["min_unit"], unit)
+            stats["max_unit"] = unit if stats["max_unit"] is None else max(stats["max_unit"], unit)
+            stats["sum_unit"] += unit
+            stats["count"] += 1
+
+        top_lines.append(
+            {
+                "vendor_name": vendor,
+                "item_code": code,
+                "description": it.get("description"),
+                "qty": qty,
+                "unit_price_sar": unit,
+                "amount_sar": amt,
+            }
+        )
+
+    for code, stats in per_item_stats.items():
+        if stats["count"]:
+            stats["avg_unit"] = stats["sum_unit"] / stats["count"]
+        else:
+            stats["avg_unit"] = None
+        stats.pop("sum_unit", None)
+        stats.pop("count", None)
+
+    top_lines = sorted(top_lines, key=lambda r: (r.get("amount_sar") or 0.0), reverse=True)[:20]
+
+    return {
+        "totals_per_vendor": [
+            {"vendor_name": v, "total_amount_sar": round(a, 2)}
+            for v, a in sorted(per_vendor.items(), key=lambda x: -x[1])
+        ],
+        "unit_price_stats_per_item": [
+            {"item_code": c, **vals} for c, vals in per_item_stats.items()
+        ],
+        "top_lines_by_amount": top_lines,
+    }
+

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -1,70 +1,42 @@
-// Single-file: call /drafts/from-file and render cards when returned (robust error handling)
 async function generateFromSingleFile() {
   const file = document.getElementById('single_file_input').files[0];
   if (!file) return;
   const fd = new FormData();
   fd.append('file', file);
-  try {
-    const resp = await fetch('/drafts/from-file', { method: 'POST', body: fd });
-    let data = {};
-    try { data = await resp.json(); } catch (_) { /* non-JSON or timeout */ }
-    if (!resp.ok) {
-      renderSingleFileError((data && data.error) ? data.error : `Request failed (HTTP ${resp.status})`);
-      return;
-    }
-    if (data && data.error) {
-      renderSingleFileError(data.error);
-      return;
-    }
-    if (data.report_type === 'procurement_summary') {
-      renderProcurementCards(data);
-    } else if (data.report_type === 'variance_insights') {
-      renderVarianceInsights(data);
-    } else {
-      showResultJSON(data);
-    }
-  } catch (e) {
-    showError(e);
+
+  const resp = await fetch('/drafts/from-file', { method: 'POST', body: fd });
+  let data = {};
+  try { data = await resp.json(); } catch (_) {}
+  if (!resp.ok) {
+    renderSingleFileError((data && data.error) ? data.error : `Request failed (HTTP ${resp.status})`);
+    return;
+  }
+  if (data && data.error) {
+    renderSingleFileError(data.error);
+    return;
+  }
+
+  const variance = (data.variance_items || []);
+  const hasVariance = Array.isArray(variance) && variance.length > 0;
+  const procurement = (data.procurement_summary && data.procurement_summary.items)
+    ? data.procurement_summary.items : [];
+  const hasProcurement = Array.isArray(procurement) && procurement.length > 0;
+
+  if (hasVariance) {
+    renderVarianceDraftCards(variance);
+  } else if (hasProcurement) {
+    if (data.message) renderNotice(data.message);
+    renderProcurementSummary({ items: procurement, insights: data.insights || {} });
+  } else {
+    renderSingleFileError('No budget/actuals found and no recognizable procurement lines. Please upload budget/actuals CSV/Excel for variance, or a quote/BOQ for procurement.');
   }
 }
 
-function renderProcurementCards(data) {
+function renderVarianceDraftCards(items) {
   const box = document.getElementById('result_box');
-  if (!data.items || !data.items.length) { box.innerText = 'No procurement items found.'; return; }
+  if (!items.length) { box.innerText = 'No variance items found.'; return; }
   box.innerHTML = '';
-  data.items.forEach(it => {
-    const div = document.createElement('div');
-    div.className = 'card';
-    div.innerHTML = `
-      <div class="card-title">${it.item_code || '—'} — SAR ${it.amount_sar ?? '—'}</div>
-      <div class="kv">Vendor: <b>${it.vendor || '—'}</b> &nbsp; | Date: ${it.doc_date || '—'}</div>
-      <div class="kv">Qty/Unit: ${it.quantity || '—'} ${it.unit || ''} &nbsp; | Unit price: ${it.unit_price_sar ?? '—'}</div>
-      <div class="desc">${(it.description || '').slice(0, 500)}</div>
-      <div class="src">Source: ${it.source}</div>
-    `;
-    box.appendChild(div);
-  });
-}
-
-function showResultJSON(data) {
-  const box = document.getElementById('result_box');
-  box.textContent = JSON.stringify(data, null, 2);
-}
-
-function showError(e) {
-  const box = document.getElementById('result_box');
-  box.textContent = 'Error: ' + (e.message || e);
-}
-
-function renderSingleFileError(e) {
-  showError(e);
-}
-
-function renderVarianceInsights(data) {
-  const box = document.getElementById('result_box');
-  if (!data.items || !data.items.length) { box.innerText = 'No variance items found.'; return; }
-  box.innerHTML = '';
-  data.items.forEach(it => {
+  items.forEach(it => {
     const div = document.createElement('div');
     div.className = 'card';
     div.innerHTML = `
@@ -73,3 +45,50 @@ function renderVarianceInsights(data) {
     box.appendChild(div);
   });
 }
+
+function renderProcurementSummary({ items, insights }) {
+  const box = document.getElementById('result_box');
+  if (!items.length) { box.innerText = 'No procurement items found.'; return; }
+  box.innerHTML = '';
+  items.forEach(it => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    div.innerHTML = `
+      <div class="card-title">${it.item_code || '—'} — SAR ${it.amount_sar ?? '—'}</div>
+      <div class="kv">Vendor: <b>${it.vendor_name || it.vendor || '—'}</b></div>
+      <div class="kv">Qty/Unit: ${it.qty || '—'} ${it.unit || ''} | Unit price: ${it.unit_price_sar ?? '—'}</div>
+      <div class="desc">${(it.description || '').slice(0, 500)}</div>`;
+    box.appendChild(div);
+  });
+
+  if (insights && (insights.totals_per_vendor || insights.top_lines_by_amount)) {
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(insights, null, 2);
+    box.appendChild(pre);
+  }
+}
+
+function renderSingleFileError(msg) {
+  const box = document.getElementById('result_box');
+  box.innerText = msg;
+}
+
+function showError(e) {
+  renderSingleFileError(e.message || e);
+}
+
+function renderNotice(msg) {
+  try {
+    const el = document.getElementById('notice') || (function(){
+      const n = document.createElement('div');
+      n.id = 'notice';
+      n.className = 'notice info';
+      document.body.prepend(n);
+      return n;
+    })();
+    el.textContent = msg;
+  } catch (_) {
+    console.warn(msg);
+  }
+}
+


### PR DESCRIPTION
## Summary
- Distinguish variance vs procurement in `/drafts/from-file`, returning insights for procurement and helpful messages when nothing detected
- Add `compute_procurement_insights` service to summarize vendor totals and unit price stats
- Update client `ui.js` to render variance draft cards or procurement summary with notices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8d2a1f99c832abe520a6d99103af2