### PR TITLE
feat: summarize change orders

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -62,9 +62,7 @@ def test_generate_drafts_change_orders_only():
         category_map=category_map,
         config=ConfigModel(materiality_pct=0, materiality_amount_sar=0),
     )
-    drafts = generate_drafts(req)
-    assert len(drafts) == 1
-    v = drafts[0].variance
-    assert v.actual_sar == 150000.0
-    assert v.budget_sar == 0.0
-    assert v.category == "Materials"
+    summary = generate_drafts(req)
+    assert summary["kind"] == "summary"
+    assert summary["insights"]["total_change_orders"] == 1
+    assert summary["insights"]["total_amount_sar"] == 150000.0


### PR DESCRIPTION
## Summary
- prevent fallback drafting from change orders when budget/actuals missing
- return summary insights for change-order-only uploads
- adjust pipeline tests for new summary behavior

## Testing
- `ruff check app/pipeline.py tests/test_pipeline.py`
- `mypy app/pipeline.py tests/test_pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9615247b4832abee40294f49b32c0