### PR TITLE
feat: add summary response union

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -43,7 +43,12 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from pydantic import BaseModel
 
-from .schemas import DraftRequest, DraftResponse, ProcurementItem, VendorSnapshot
+from .schemas import (
+    DraftRequest,
+    ProcurementItem,
+    VendorSnapshot,
+    DraftsOrSummary,
+)
 from .pipeline import generate_drafts
 from .services.csv_loader import parse_tabular
 from app.services.singlefile import process_single_file, draft_bilingual_procurement_card
@@ -697,7 +702,7 @@ async def get_job(job_id: str):
 def ceo_ui():
     return FileResponse("app/templates/ui.html")
 
-@app.post("/drafts", response_model=List[DraftResponse], dependencies=deps)
+@app.post("/drafts", response_model=DraftsOrSummary, dependencies=deps)
 def create_drafts(req: DraftRequest):
     """Create EN/AR variance explanation drafts."""
     return generate_drafts(req)
@@ -1005,7 +1010,7 @@ def _build_payload(
     }
 
 
-@app.post("/drafts/upload", response_model=List[DraftResponse])
+@app.post("/drafts/upload", response_model=DraftsOrSummary)
 async def drafts_upload(
     budget_actuals: UploadFile = File(..., description="Budget–Actuals CSV/XLS/XLSX"),
     change_orders: UploadFile = File(..., description="Change Orders CSV/XLS/XLSX"),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,7 +2,8 @@
 """Pydantic data models for the Variance Drafts service."""
 
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Any, Dict, Union
+from typing_extensions import Literal
 
 class BudgetActualRow(BaseModel):
     project_id: str
@@ -66,6 +67,14 @@ class DraftResponse(BaseModel):
     draft_ar: Optional[str] = None
     analyst_notes: Optional[str] = None
 
+
+class SummaryResponse(BaseModel):
+    kind: Literal["summary"] = "summary"
+    message: str
+    insights: Dict[str, Any] = Field(default_factory=dict)
+
+
+DraftsOrSummary = Union[List[DraftResponse], SummaryResponse]
 
 class ProcurementItem(BaseModel):
     """Lightweight summary card for single-file procurement uploads."""


### PR DESCRIPTION
## Summary
- add `SummaryResponse` model and `DraftsOrSummary` union for API flexibility
- update `/drafts` and `/drafts/upload` endpoints to return list of drafts or summary

## Testing
- `ruff check app/main.py app/schemas.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96d69e004832abf25c579986b105d