### PR TITLE
feat: add workbook insights fallback

### DIFF
--- a/app/services/insights.py
+++ b/app/services/insights.py
@@ -1,66 +1,224 @@
-from typing import List, Dict, Any
+from __future__ import annotations
+from typing import Any, Dict, List, Tuple
+import pandas as pd
+import numpy as np
+import math
+import re
+from collections import Counter, defaultdict
 
+# ---------- Helpers ----------
+NUMERIC_NA_REPR = None
 
-def _num(x):
+def _norm_col(c: Any) -> str:
+    return str(c).strip()
+
+def _lowset(cols) -> Dict[str, str]:
+    return {str(c).strip().lower(): str(c).strip() for c in cols}
+
+def _is_date_series(s: pd.Series) -> bool:
     try:
-        return float(str(x).replace(",", "").strip())
+        pd.to_datetime(s, errors="raise")
+        return True
     except Exception:
-        return None
+        return False
 
+def _numeric_cols(df: pd.DataFrame) -> List[str]:
+    return [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
 
-def compute_procurement_insights(items: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Summarize procurement lines for more meaningful single-file output."""
-    per_vendor: Dict[str, float] = {}
-    per_item_stats: Dict[str, Dict[str, float]] = {}
-    top_lines: List[Dict[str, Any]] = []
+def _categorical_cols(df: pd.DataFrame) -> List[str]:
+    cats = []
+    for c in df.columns:
+        if pd.api.types.is_numeric_dtype(df[c]):
+            continue
+        # exclude obviously unique-like columns (e.g., long text)
+        nunique = df[c].nunique(dropna=True)
+        if 1 <= nunique <= max(50, int(len(df) * 0.1)):
+            cats.append(c)
+    return cats
 
-    for it in items:
-        vendor = (it.get("vendor_name") or "").strip() or "Unknown vendor"
-        qty = _num(it.get("qty")) or 0
-        unit = _num(it.get("unit_price_sar")) or 0
-        amt = _num(it.get("amount_sar")) or (qty * unit)
-        code = (it.get("item_code") or "").strip() or "-"
+def _pick_amount_col(cols_low: Dict[str, str]) -> str | None:
+    for key in (
+        "amount","amount_sar","total","total_sar","line total","line_total","net amount",
+        "value","total price","total price (sar)","extended amount","subtotal","grand total"
+    ):
+        if key in cols_low:
+            return cols_low[key]
+    return None
 
-        per_vendor[vendor] = per_vendor.get(vendor, 0.0) + (amt or 0.0)
+def _pick_qty_col(cols_low: Dict[str, str]) -> str | None:
+    for key in ("qty","quantity","qty (nos)","nos","units","no.","no of doors","no of units"):
+        if key in cols_low:
+            return cols_low[key]
+    return None
 
-        stats = per_item_stats.setdefault(
-            code, {"min_unit": None, "max_unit": None, "sum_unit": 0.0, "count": 0}
+def _pick_unit_price_col(cols_low: Dict[str, str]) -> str | None:
+    for key in ("unit price","unit_price","unit rate","unit rate (sar)","unit price (sar)","rate","price per unit","price/unit","u rate","u.rate"):
+        if key in cols_low:
+            return cols_low[key]
+    return None
+
+def _pick_vendor_col(cols_low: Dict[str, str]) -> str | None:
+    for key in ("vendor","vendor name","vendor_name","supplier","supplier name","company","quoted by","bidder","vendor/supplier"):
+        if key in cols_low:
+            return cols_low[key]
+    return None
+
+def _pick_desc_col(cols_low: Dict[str, str]) -> str | None:
+    for key in ("description","description of works","item description","work description","scope","item"):
+        if key in cols_low:
+            return cols_low[key]
+    return None
+
+# ---------- Public API ----------
+
+def generate_insights_for_workbook(sheets: Dict[str, pd.DataFrame]) -> Dict[str, Any]:
+    """
+    Summarize arbitrary tabular workbooks that DO NOT contain budget/actual pairs.
+    Produces a compact 'insights' payload consumable by the UI.
+    """
+    profile: Dict[str, Any] = {"sheets": []}
+    tables: Dict[str, Any] = {}
+    highlights: List[str] = []
+    cards: List[Dict[str, Any]] = []
+
+    grand_amount_total: float = 0.0
+    vendor_totals_accum: Counter[str] = Counter()
+    spend_by_desc_accum: Counter[str] = Counter()
+    spread_rows: List[Dict[str, Any]] = []
+
+    for sheet_name, df in sheets.items():
+        if df is None or df.empty:
+            profile["sheets"].append({"sheet": sheet_name, "rows": 0, "cols": 0})
+            continue
+
+        df = df.copy()
+        df.columns = [_norm_col(c) for c in df.columns]
+        profile["sheets"].append({"sheet": sheet_name, "rows": int(df.shape[0]), "cols": int(df.shape[1])})
+
+        # Column profiling
+        cols = []
+        for c in df.columns:
+            s = df[c]
+            dtype = str(s.dtype)
+            missing = float(s.isna().mean()) if len(s) else 0.0
+            is_date = _is_date_series(s) if dtype == "object" else False
+            cols.append({"column": c, "dtype": dtype, "missing_rate": round(missing, 4), "date_like": bool(is_date)})
+        tables[f"{sheet_name}::columns_profile"] = cols
+
+        # Numeric summary
+        num_cols = _numeric_cols(df)
+        if num_cols:
+            summary_rows = []
+            for c in num_cols:
+                s = pd.to_numeric(df[c], errors="coerce")
+                s = s.dropna()
+                if s.empty: 
+                    continue
+                summary_rows.append({
+                    "column": c,
+                    "count": int(s.count()),
+                    "sum": float(s.sum()),
+                    "mean": float(s.mean()),
+                    "median": float(s.median()),
+                    "min": float(s.min()),
+                    "max": float(s.max()),
+                })
+            if summary_rows:
+                tables[f"{sheet_name}::numeric_summary"] = summary_rows
+
+        # Categorical summary
+        cat_cols = _categorical_cols(df)
+        for c in cat_cols:
+            vc = (df[c].astype(str).replace({"nan": None}).dropna()).value_counts().head(10)
+            tables[f"{sheet_name}::top_values::{c}"] = [{"value": str(k), "count": int(v)} for k, v in vc.items()]
+
+        # Domain-aware cost insights
+        low = _lowset(df.columns)
+        c_amount = _pick_amount_col(low)
+        c_qty = _pick_qty_col(low)
+        c_uprice = _pick_unit_price_col(low)
+        c_vendor = _pick_vendor_col(low)
+        c_desc = _pick_desc_col(low)
+
+        if c_amount:
+            amt = pd.to_numeric(df[c_amount], errors="coerce")
+            total_amt = float(amt.dropna().sum())
+            grand_amount_total += total_amt
+            cards.append({"sheet": sheet_name, "title": "Sheet total amount", "value_sar": round(total_amt, 2)})
+
+        if c_vendor and c_amount:
+            grp = (df[[c_vendor, c_amount]]
+                   .assign(_amt=pd.to_numeric(df[c_amount], errors="coerce"))
+                   .dropna(subset=["_amt"]))
+            if not grp.empty:
+                vt = grp.groupby(c_vendor)["_amt"].sum().sort_values(ascending=False).head(10)
+                vendor_totals_accum.update({str(k): float(v) for k, v in vt.items()})
+                tables[f"{sheet_name}::vendor_totals"] = [{"vendor": str(k), "total_sar": float(v)} for k, v in vt.items()]
+
+        if c_desc and c_amount:
+            ds = (df[[c_desc, c_amount]]
+                  .assign(_amt=pd.to_numeric(df[c_amount], errors="coerce"))
+                  .dropna(subset=["_amt"]))
+            if not ds.empty:
+                top_items = ds.groupby(c_desc)["_amt"].sum().sort_values(ascending=False).head(10)
+                spend_by_desc_accum.update({str(k): float(v) for k, v in top_items.items()})
+                tables[f"{sheet_name}::top_items_by_spend"] = [{"description": str(k), "total_sar": float(v)} for k, v in top_items.items()]
+
+        # Vendor spread insights (if we have vendor + unit price + description)
+        if c_vendor and c_uprice and c_desc:
+            tmp = df[[c_vendor, c_uprice, c_desc]].copy()
+            tmp["_u"] = pd.to_numeric(tmp[c_uprice], errors="coerce")
+            tmp = tmp.dropna(subset=["_u", c_vendor, c_desc])
+            if not tmp.empty:
+                for desc, grp in tmp.groupby(c_desc):
+                    if grp[c_vendor].nunique() < 2:
+                        continue
+                    umin = grp.loc[grp["_u"].idxmin()]
+                    umax = grp.loc[grp["_u"].idxmax()]
+                    min_u = float(umin["_u"]); max_u = float(umax["_u"])
+                    if min_u <= 0: 
+                        continue
+                    spread_pct = (max_u/min_u - 1.0) * 100.0
+                    spread_rows.append({
+                        "description": str(desc),
+                        "min_vendor": str(umin[c_vendor]),
+                        "min_unit_sar": round(min_u, 2),
+                        "max_vendor": str(umax[c_vendor]),
+                        "max_unit_sar": round(max_u, 2),
+                        "unit_spread_sar": round(max_u - min_u, 2),
+                        "spread_pct": round(spread_pct, 2),
+                    })
+
+    # Workbook-level aggregates
+    if vendor_totals_accum:
+        vt_sorted = sorted(vendor_totals_accum.items(), key=lambda kv: kv[1], reverse=True)
+        tables["workbook::vendor_totals"] = [{"vendor": v, "total_sar": round(t, 2)} for v, t in vt_sorted[:20]]
+        if vt_sorted:
+            v, t = vt_sorted[0]
+            highlights.append(f"Top vendor by spend: {v} (≈ {round(t,2)} SAR).")
+
+    if spend_by_desc_accum:
+        items_sorted = sorted(spend_by_desc_accum.items(), key=lambda kv: kv[1], reverse=True)[:5]
+        top_desc = ", ".join([f"{d} (≈ {round(v,2)} SAR)" for d, v in items_sorted])
+        highlights.append(f"Largest cost drivers: {top_desc}.")
+
+    if spread_rows:
+        spread_rows = sorted(spread_rows, key=lambda r: (r.get("unit_spread_sar",0), r.get("spread_pct",0)), reverse=True)[:20]
+        tables["workbook::vendor_spreads"] = spread_rows
+        max_spread = spread_rows[0]
+        highlights.append(
+            f"Bid spread detected for '{max_spread['description']}': "
+            f"{max_spread['min_vendor']} {max_spread['min_unit_sar']} vs "
+            f"{max_spread['max_vendor']} {max_spread['max_unit_sar']} SAR "
+            f"({max_spread['spread_pct']}% Δ)."
         )
-        if unit:
-            stats["min_unit"] = unit if stats["min_unit"] is None else min(stats["min_unit"], unit)
-            stats["max_unit"] = unit if stats["max_unit"] is None else max(stats["max_unit"], unit)
-            stats["sum_unit"] += unit
-            stats["count"] += 1
 
-        top_lines.append(
-            {
-                "vendor_name": vendor,
-                "item_code": code,
-                "description": it.get("description"),
-                "qty": qty,
-                "unit_price_sar": unit,
-                "amount_sar": amt,
-            }
-        )
-
-    for code, stats in per_item_stats.items():
-        if stats["count"]:
-            stats["avg_unit"] = stats["sum_unit"] / stats["count"]
-        else:
-            stats["avg_unit"] = None
-        stats.pop("sum_unit", None)
-        stats.pop("count", None)
-
-    top_lines = sorted(top_lines, key=lambda r: (r.get("amount_sar") or 0.0), reverse=True)[:20]
+    if grand_amount_total > 0:
+        cards.insert(0, {"title": "Workbook total amount", "value_sar": round(grand_amount_total, 2)})
 
     return {
-        "totals_per_vendor": [
-            {"vendor_name": v, "total_amount_sar": round(a, 2)}
-            for v, a in sorted(per_vendor.items(), key=lambda x: -x[1])
-        ],
-        "unit_price_stats_per_item": [
-            {"item_code": c, **vals} for c, vals in per_item_stats.items()
-        ],
-        "top_lines_by_amount": top_lines,
+        "profile": profile,
+        "tables": tables,      # dict of named tables
+        "cards": cards,        # small KPI cards
+        "highlights": highlights
     }
-

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -173,3 +173,69 @@ function toast(msg) {
   setTimeout(()=>t.remove(), 2000);
 }
 
+// --- Insights rendering ---
+function renderResult(payload) {
+  // existing rendering...
+  if (!payload) return;
+  if (payload.mode === 'insights' && payload.insights) {
+    renderInsights(payload.insights);
+  }
+  if (payload.diagnostics) {
+    renderDiagnostics(payload.diagnostics);
+  }
+}
+
+function renderInsights(ins) {
+  const root = document.getElementById('results') || document.body;
+  const wrap = document.createElement('section');
+  wrap.className = 'insights';
+
+  // Highlights
+  if (Array.isArray(ins.highlights) && ins.highlights.length) {
+    const h = document.createElement('div');
+    h.innerHTML = '<h3>Highlights</h3>';
+    const ul = document.createElement('ul');
+    ins.highlights.forEach(t => {
+      const li = document.createElement('li'); li.textContent = t; ul.appendChild(li);
+    });
+    h.appendChild(ul);
+    wrap.appendChild(h);
+  }
+
+  // KPI cards
+  if (Array.isArray(ins.cards) && ins.cards.length) {
+    const cards = document.createElement('div');
+    cards.style.display = 'grid';
+    cards.style.gridTemplateColumns = 'repeat(auto-fit, minmax(200px, 1fr))';
+    cards.style.gap = '12px';
+    ins.cards.forEach(c => {
+      const card = document.createElement('div');
+      card.style.border = '1px solid #ddd'; card.style.borderRadius = '8px'; card.style.padding = '10px';
+      const title = document.createElement('div'); title.textContent = c.title || c.sheet || 'Metric'; title.style.fontWeight = '600';
+      const val = document.createElement('div'); val.textContent = (c.value_sar !== undefined) ? `${c.value_sar} SAR` : (c.value || '');
+      card.appendChild(title); card.appendChild(val); cards.appendChild(card);
+    });
+    wrap.appendChild(cards);
+  }
+
+  // Tables
+  if (ins.tables && typeof ins.tables === 'object') {
+    const keys = Object.keys(ins.tables);
+    keys.forEach(name => {
+      const tblData = ins.tables[name];
+      const sec = document.createElement('details');
+      sec.open = false;
+      const sum = document.createElement('summary');
+      sum.textContent = name;
+      sec.appendChild(sum);
+      const pre = document.createElement('pre');
+      pre.style.whiteSpace = 'pre-wrap';
+      pre.textContent = JSON.stringify(tblData, null, 2);
+      sec.appendChild(pre);
+      wrap.appendChild(sec);
+    });
+  }
+
+  root.appendChild(wrap);
+}
+


### PR DESCRIPTION
## Summary
- add comprehensive workbook insights generator for non-budget data
- route single-file processing to insights or quote compare based on workbook contents
- render insights mode in static UI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b060b8c0832aa46a8c0f437aa987