### PR TITLE
Expose diagnostics for single-file parsing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1102,16 +1102,8 @@ async def drafts_from_file(
 ):
     data = await file.read()
     parsed = parse_single_file(file.filename, data)
-
-    # If we found variance items, return them as-is (UI already knows how to render)
-    if "variance_items" in parsed:
-        return JSONResponse(parsed)
-
-    # Otherwise, return Procurement Summary skeleton (UI will render dedicated cards)
-    if "procurement_summary" in parsed:
-        return JSONResponse(parsed)
-
-    return JSONResponse({"procurement_summary": {"items": [], "meta": {}}})
+    status = 400 if parsed.get("error") else 200
+    return JSONResponse(parsed, status_code=status)
 
 
 # ---------------- In-memory job store (lightweight) ------------------------

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -9,10 +9,12 @@ async function generateFromSingleFile() {
   try { data = await resp.json(); } catch (_) {}
   if (!resp.ok) {
     renderSingleFileError((data && data.error) ? data.error : `Request failed (HTTP ${resp.status})`);
+    if (data && data.diagnostics) { renderDiagnostics(data.diagnostics); }
     return;
   }
   if (data && data.error) {
     renderSingleFileError(data.error);
+    if (data.diagnostics) { renderDiagnostics(data.diagnostics); }
     return;
   }
 

--- a/tests/test_singlefile_intake_diagnostics.py
+++ b/tests/test_singlefile_intake_diagnostics.py
@@ -1,0 +1,20 @@
+import io
+import pandas as pd
+
+from app.parsers.single_file_intake import parse_single_file
+
+
+def _csv_bytes(df: pd.DataFrame) -> bytes:
+    bio = io.BytesIO()
+    df.to_csv(bio, index=False)
+    return bio.getvalue()
+
+
+def test_parse_single_file_returns_diagnostics():
+    df = pd.DataFrame({"budget": [100], "actual": [120]})
+    b = _csv_bytes(df)
+    resp = parse_single_file("simple.csv", b)
+    assert "diagnostics" in resp
+    diag = resp["diagnostics"]
+    assert diag.get("correlation_id")
+    assert isinstance(diag.get("events"), list)


### PR DESCRIPTION
## Summary
- instrument `parse_single_file` with DiagnosticContext and return structured diagnostics
- propagate diagnostics in `/drafts/from-file` endpoint and render them on the UI even for errors
- add test verifying diagnostics are emitted

## Testing
- `ruff check .` *(fails: F401, E401, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9c26ce810832aa97d86c5fd007bcd