### PR TITLE
Expose variance_items for quote comparison

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, UploadFile, File
 import asyncio
-from typing import Dict, Any, List
 
 from app.parsers.procurement_pdf import parse_procurement_pdf
 from app.services.singlefile import process_single_file
@@ -62,8 +61,8 @@ async def from_file(file: UploadFile = File(...)):
         if processed.get("mode") == "quote_compare":
             return {
                 "kind": "quote_compare",
-                # 'variance_items' here are "spreads" flagged by materiality rules
-                "spreads": processed.get("variance_items") or [],
+                # expose under the stable name the UI expects
+                "variance_items": processed.get("variance_items") or [],
                 "vendor_totals": processed.get("vendor_totals") or [],
                 "insights": processed.get("insights", {}),
                 "message": processed.get("message"),


### PR DESCRIPTION
## Summary
- surface quote comparison variance data under a consistent `variance_items` key from the backend
- render quote comparison tables with min/max vendor spreads and flexible vendor totals in the UI
- adjust front-end file input ID and detection for `quote_compare` results

## Testing
- `pytest -q`
- `ruff check .` (fails: unused imports and other lint issues across repository)
- `ruff check app/routers/drafts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9e6d28d98832abba89f08edeb7753