### PR TITLE
Add insights fallback and configurable timeouts for single-file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ Docs: `http://localhost:8000/docs`
 
 ## Example payload
 (see /data/templates for sample CSV/XLSX files and README for example JSON)
+
+## Environment variables
+The service exposes several knobs for timeouts and concurrency. All have safe defaults and may be overridden per deployment:
+
+```
+OPENAI_TIMEOUT=30       # seconds per OpenAI request
+OPENAI_MAX_RETRIES=2    # OpenAI client retries
+PDF_PARSE_TIMEOUT=45    # seconds to spend parsing PDFs
+
+WEB_CONCURRENCY=4       # Gunicorn worker processes
+WEB_THREADS=8           # threads per worker
+WEB_TIMEOUT=240         # request timeout in seconds
+WEB_KEEPALIVE=5         # keepalive in seconds
+```

--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -44,8 +44,9 @@ def generate_draft(v: VarianceItem, cfg: ConfigModel) -> Tuple[str, str]:
     try:
         from openai import OpenAI
 
-        timeout = int(os.getenv("OPENAI_TIMEOUT", "10"))
-        client = OpenAI(api_key=api_key, timeout=timeout, max_retries=0)
+        timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
+        retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+        client = OpenAI(api_key=api_key, timeout=timeout, max_retries=retries)
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": user_prompt + ("\n\n" + ar_instr if ar_instr else "")},

--- a/app/main.py
+++ b/app/main.py
@@ -52,11 +52,12 @@ from .schemas import (
 from .pipeline import generate_drafts
 from .services.csv_loader import parse_tabular
 from app.services.singlefile import process_single_file, draft_bilingual_procurement_card
-from app.parsers.single_file_intake import parse_single_file
 from .llm.extract_from_text import extract_items_via_llm
 from app.parsers.single_file import analyze_single_file
+from app.routers import drafts as drafts_router
 
 app: FastAPI = FastAPI(title="Oaktree Variance Drafts API", version="0.1.0")
+app.include_router(drafts_router.router)
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -1090,20 +1091,6 @@ async def analyze_single_file_endpoint(
         bilingual=bilingual,
         no_speculation=no_speculation,
     )
-
-
-@app.post("/drafts/from-file")
-async def drafts_from_file(
-    file: UploadFile = File(...),
-    bilingual: bool = Form(True),
-    no_speculation: bool = Form(True),
-    materiality_pct: float = Form(5.0),
-    materiality_amount_sar: float = Form(100000.0),
-):
-    data = await file.read()
-    parsed = parse_single_file(file.filename, data)
-    status = 400 if parsed.get("error") else 200
-    return JSONResponse(parsed, status_code=status)
 
 
 # ---------------- In-memory job store (lightweight) ------------------------

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, UploadFile, File
 import asyncio
+import os
 
 from app.parsers.procurement_pdf import parse_procurement_pdf
 from app.services.singlefile import process_single_file
+from app.parsers.single_file_intake import parse_single_file
 from app.services.insights import compute_procurement_insights
 
 router = APIRouter()
@@ -22,13 +24,14 @@ async def from_file(file: UploadFile = File(...)):
 
         if is_pdf:
             # Parse PDFs in a worker thread with a hard timeout to avoid hangs/502s.
+            pdf_timeout = int(os.getenv("PDF_PARSE_TIMEOUT", "45"))
             try:
                 result = await asyncio.wait_for(
                     asyncio.to_thread(parse_procurement_pdf, data),
-                    timeout=25,
+                    timeout=pdf_timeout,
                 )
             except asyncio.TimeoutError:
-                return {"error": "PDF parsing timed out after 25 seconds."}
+                return {"error": f"PDF parsing timed out after {pdf_timeout} seconds."}
 
             items = (result or {}).get("items") or []
             if items:
@@ -45,41 +48,19 @@ async def from_file(file: UploadFile = File(...)):
             }
 
         # Non-PDF (CSV/Excel/Word/Text)
-        processed = await asyncio.to_thread(process_single_file, file.filename, data)
-        processed = processed or {}
+        parsed = await asyncio.to_thread(parse_single_file, file.filename, data)
+        parsed = parsed or {}
 
-        if processed.get("mode") == "variance":
-            variance_items = processed.get("variances") or []
+        variance_items = parsed.get("variance_items")
+        if variance_items:
             return {
                 "kind": "variance",
                 "variance_items": variance_items,
-                "insights": processed.get("insights", {}),
+                "insights": parsed.get("insights", {}),
+                "diagnostics": parsed.get("diagnostics"),
             }
 
-        # NEW: quote-compare workbooks (e.g., doors_quotes_complete.xlsx)
-        # Map the service payload through as a first-class kind so the UI can render it.
-        if processed.get("mode") == "quote_compare":
-            return {
-                "kind": "quote_compare",
-                # expose under the stable name the UI expects
-                "variance_items": processed.get("variance_items") or [],
-                "vendor_totals": processed.get("vendor_totals") or [],
-                "insights": processed.get("insights", {}),
-                "message": processed.get("message"),
-                # pass diagnostics through when present
-                "diagnostics": processed.get("diagnostics"),
-            }
-
-        # NEW: Workbook-level insights (no budget/actuals and no recognizable line items)
-        if processed.get("mode") == "insights":
-            return {
-                "kind": "insights",
-                "insights": processed.get("insights", {}),
-                "diagnostics": processed.get("diagnostics"),
-                "message": processed.get("message"),
-            }
-
-        items = processed.get("items") or []
+        items = (parsed.get("procurement_summary") or {}).get("items") or []
         if items:
             insights = compute_procurement_insights(items)
             return {
@@ -87,6 +68,18 @@ async def from_file(file: UploadFile = File(...)):
                 "message": "No budget/actuals detected — showing procurement summary.",
                 "procurement_summary": {"items": items},
                 "insights": insights,
+                "diagnostics": parsed.get("diagnostics"),
+            }
+
+        # Fallback: try the workbook insights pipeline
+        processed = await asyncio.to_thread(process_single_file, file.filename, data)
+        processed = processed or {}
+        if processed.get("mode") == "insights":
+            return {
+                "kind": "insights",
+                "insights": processed.get("insights", {}),
+                "diagnostics": processed.get("diagnostics"),
+                "message": processed.get("message"),
             }
 
         return {

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,10 +1,12 @@
-workers = 2
+import os
+
+workers = int(os.getenv("WEB_CONCURRENCY", "4"))
 worker_class = "uvicorn.workers.UvicornWorker"
 bind = "0.0.0.0:8000"
-timeout = 240
+timeout = int(os.getenv("WEB_TIMEOUT", "240"))
 graceful_timeout = 30
-keepalive = 120
-threads = 4
+keepalive = int(os.getenv("WEB_KEEPALIVE", "5"))
+threads = int(os.getenv("WEB_THREADS", "8"))
 accesslog = "-"
 errorlog = "-"
 loglevel = "info"

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+def test_from_file_no_variance():
+    client = TestClient(app)
+    files = {"file": ("note.txt", b"Procurement lines only, no budget/actuals", "text/plain")}
+    r = client.post("/drafts/from-file", files=files)
+    assert r.status_code == 200
+    j = r.json()
+    assert j["kind"] in ("procurement", "insights")
+    if j["kind"] == "procurement":
+        assert "procurement_summary" in j and "insights" in j

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -21,6 +21,7 @@ class DummyOpenAI:
 def test_generate_draft_timeout(monkeypatch):
     os.environ["OPENAI_API_KEY"] = "sk-test"
     os.environ["OPENAI_TIMEOUT"] = "1"
+    os.environ["OPENAI_MAX_RETRIES"] = "5"
     monkeypatch.setattr("openai.OpenAI", DummyOpenAI)
 
     v = VarianceItem(
@@ -38,7 +39,8 @@ def test_generate_draft_timeout(monkeypatch):
     en, ar = generate_draft(v, cfg)
     assert "variance" in en
     assert DummyOpenAI.last_kwargs["timeout"] == 1
-    assert DummyOpenAI.last_kwargs["max_retries"] == 0
+    assert DummyOpenAI.last_kwargs["max_retries"] == 5
     assert ar  # bilingual fallback text
     os.environ.pop("OPENAI_API_KEY")
     os.environ.pop("OPENAI_TIMEOUT")
+    os.environ.pop("OPENAI_MAX_RETRIES")


### PR DESCRIPTION
## Summary
- route all `/drafts/from-file` traffic through dedicated router
- allow OpenAI and PDF parsing timeouts to be tuned via env vars
- export basic procurement insights when no budget/actual variance is found
- document timeout/env settings and make gunicorn sizing configurable

## Testing
- `pytest`
- `ruff check .` *(fails: unused imports and formatting across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f8e65220832ab81c9440a4eb94fd