### PR TITLE
Add Markdown reporting for single-file analysis

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -105,6 +105,7 @@ async def from_file(file: UploadFile = File(...)):
                     **processed.get("insights", {}),
                 },
                 "diagnostics": processed.get("diagnostics"),
+                "report_markdown": processed.get("report_markdown"),
                 "message": processed.get("message") or "Price comparison insights.",
             }
 


### PR DESCRIPTION
## Summary
- generate Markdown summaries for quote comparisons and generic workbooks
- return generated report_markdown in single-file endpoint responses

## Testing
- `pytest`
- `ruff check .` *(fails: F401 `typing.Tuple` imported but unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0bb69a7c832ab50f7c601ac48e93