### PR TITLE
Enforce API key on file upload routes and tweak insights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+# Install Python deps from the project's manifest (includes pandas, openpyxl, pdf libs, etc.)
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy source after deps for better Docker layer caching
 COPY app /app/app
 COPY README.md /app/README.md
-RUN pip install --no-cache-dir fastapi uvicorn pydantic openai
+COPY gunicorn.conf.py /app/gunicorn.conf.py
+
 EXPOSE 8000
 ENV PYTHONUNBUFFERED=1
-CMD [ "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000" ]
+
+# Use gunicorn in containers (keeps parity with provided config)
+CMD [ "gunicorn", "-c", "gunicorn.conf.py", "app.main:app" ]

--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,6 @@ from app.parsers.single_file import analyze_single_file
 from app.routers import drafts as drafts_router
 
 app: FastAPI = FastAPI(title="Oaktree Variance Drafts API", version="0.1.0")
-app.include_router(drafts_router.router)
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -629,6 +628,8 @@ def require_api_key(x_api_key: str | None = Header(default=None, alias="x-api-ke
 
 
 deps = [Depends(require_api_key)] if REQUIRE_API_KEY else []
+
+app.include_router(drafts_router.router, dependencies=deps)
 
 @app.get("/health")
 def health():

--- a/app/services/insights.py
+++ b/app/services/insights.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 import pandas as pd
 import math
 from collections import Counter, defaultdict
@@ -276,24 +276,21 @@ def compute_variance_insights(variance_items: List[Dict[str, Any]]) -> Dict[str,
         if a is not None:
             tot_actual += a
 
-    tot_variance = (tot_actual - tot_budget) if (not math.isnan(tot_actual) and not math.isnan(tot_budget)) else None
+    tot_variance: Optional[float] = (
+        (tot_actual - tot_budget)
+        if (not math.isnan(tot_actual) and not math.isnan(tot_budget))
+        else None
+    )
     over = [r for r in rows if r.get("variance_sar") is not None and r.get("variance_sar") > 0]
     under = [r for r in rows if r.get("variance_sar") is not None and r.get("variance_sar") < 0]
     top_overruns = sorted(over, key=lambda r: r["variance_sar"], reverse=True)[:10]
     top_underruns = sorted(under, key=lambda r: r["variance_sar"])[:10]
 
-    pct_overrun = None
-    try:
-        pct_overrun = ((tot_actual - tot_budget) / tot_budget * 100.0) if tot_budget else None
-    except Exception:
-        pct_overrun = None
-
     return {
-        "summary": {
-            "total_budget_sar": round(tot_budget, 2),
-            "total_actual_sar": round(tot_actual, 2),
-            "total_variance_sar": round(tot_variance, 2) if tot_variance is not None else None,
-            "overall_overrun_pct": round(pct_overrun, 2) if pct_overrun is not None else None,
+        "totals": {
+            "budget_sar": round(tot_budget, 2),
+            "actual_sar": round(tot_actual, 2),
+            "variance_sar": round(tot_variance, 2) if tot_variance is not None else None,
         },
         "top_overruns": top_overruns,
         "top_underruns": top_underruns,

--- a/tests/test_drafts_from_file_multisheet.py
+++ b/tests/test_drafts_from_file_multisheet.py
@@ -2,7 +2,9 @@ import io
 import pandas as pd
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.main import app, require_api_key
+
+app.dependency_overrides[require_api_key] = lambda: None
 
 
 def _multi_sheet_bytes() -> bytes:

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
-from app.main import app
+from app.main import app, require_api_key
+
+app.dependency_overrides[require_api_key] = lambda: None
 
 def test_from_file_no_variance():
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- refine variance insights output to expose budget, actual and variance totals
- require API key for `/drafts/from-file` via router dependencies
- refresh Dockerfile to install project requirements and run under gunicorn
- update tests to override API key requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2781392c832abcfb282102605a15