### PR TITLE
Handle single-file uploads without variance

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -29,13 +29,15 @@ async def from_file(file: UploadFile = File(...)):
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 
-        # Path B: Procurement summary / economic insights
+        # Path B: No variance detected → show summary + economic analysis + insights
         ps = (parsed.get("procurement_summary") or {}).get("items") or []
         if ps:
+            analysis = compute_procurement_insights(ps)
             return {
-                "kind": "procurement",
-                "procurement_summary": {"items": ps},
-                "insights": compute_procurement_insights(ps),
+                "kind": "insights",
+                "summary": {"items": ps},
+                "economic_analysis": analysis,
+                "insights": analysis,
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -9,6 +9,5 @@ def test_from_file_no_variance():
     r = client.post("/drafts/from-file", files=files)
     assert r.status_code == 200
     j = r.json()
-    assert j["kind"] in ("procurement", "insights")
-    if j["kind"] == "procurement":
-        assert "procurement_summary" in j and "insights" in j
+    assert j["kind"] == "insights"
+    assert "summary" in j and "economic_analysis" in j and "insights" in j


### PR DESCRIPTION
## Summary
- Return summary, economic analysis, and insights when single-file uploads lack budget/actual pairs
- Update test to expect the new insights payload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2e19e240832ab761aa40ecfaaec9