### PR TITLE
Provide summaries and insights when variance data is missing

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -35,6 +35,7 @@ async def from_file(file: UploadFile = File(...)):
             analysis = compute_procurement_insights(ps)
             return {
                 "kind": "insights",
+                "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
                 "summary": {"items": ps},
                 "economic_analysis": analysis,
                 "insights": analysis,

--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -403,7 +403,7 @@
         return;
       }
 
-      setStatus('No variance items found.');
+      setStatus('No budget-vs-actual data detected.');
     } catch (e) {
       setStatus('Load failed');
       showError(e.message || e.toString());

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -81,7 +81,7 @@ function renderInsights(ins) {
 
 function renderVarianceDraftCards(items) {
   const box = document.getElementById('result_box');
-  if (!items.length) { box.innerText = 'No variance items found.'; return; }
+  if (!items.length) { box.innerText = 'No budget-vs-actual data detected.'; return; }
   box.innerHTML = '';
   items.forEach(it => {
     const div = document.createElement('div');

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -468,7 +468,7 @@
     });
 
     if (!items.length) {
-      $('result').textContent = 'No variance items found.';
+      $('result').textContent = 'No budget-vs-actual data detected.';
       return;
     }
 
@@ -543,6 +543,7 @@
   }
 
   function renderFromFileResult(data) {
+    if (data.message) { setStatus(data.message); }
     if (data.variance_items && data.variance_items.length) {
       renderResult({ variances: data.variance_items });
       return;
@@ -560,7 +561,7 @@
       renderInsights(data.insights);
       return;
     }
-    $('result').textContent = 'No variance items found.';
+    $('result').textContent = 'No budget-vs-actual data detected.';
   }
 
   function renderProcurementSummary({ items, insights }) {

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -11,3 +11,5 @@ def test_from_file_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary" in j and "economic_analysis" in j and "insights" in j
+    assert "message" in j
+    assert "budget-vs-actual" in j["message"].lower()


### PR DESCRIPTION
## Summary
- Return a helpful message with summary, economic analysis, and insights when uploads lack budget vs. actual data
- Surface missing-variance message and procurement summary in the UI instead of "No variance items found"
- Cover fallback behavior with a test that checks for the new message

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba481424c8832aa5d5d3ab27673189