### PR TITLE
Handle missing budget data by returning summary insights

### DIFF
--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -453,6 +453,11 @@
   });
 
   function renderResult(data) {
+    if (data && data.kind === 'summary') {
+      const ins = Object.assign({ title: data.message || 'Summary' }, data.insights || {});
+      renderInsights(ins);
+      return;
+    }
     // Normalize items
     const items = Array.isArray(data?.variances) ? data.variances : (Array.isArray(data) ? data : []);
     const container = document.createElement('div');
@@ -604,7 +609,8 @@
       : '';
     const div = document.createElement('section');
     div.className = 'report__card';
-    div.innerHTML = `<div class="card__head"><div><h3>Workbook Insights</h3></div></div>${highlights}${cards}`;
+    const title = escapeHtml(ins.title || 'Workbook Insights');
+    div.innerHTML = `<div class="card__head"><div><h3>${title}</h3></div></div>${highlights}${cards}`;
     box.appendChild(div);
     function appendTable(title, rows, cols) {
       if (!rows || !rows.length) return;
@@ -620,6 +626,13 @@
     }
     appendTable('Top vendors by spend', (ins.tables && ins.tables['workbook::vendor_totals']) || [], ['vendor','total_sar']);
     appendTable('Largest bid spreads', (ins.tables && ins.tables['workbook::vendor_spreads']) || [], ['description','min_vendor','min_unit_sar','max_vendor','max_unit_sar','spread_pct']);
+    if (ins.tables) {
+      for (const [key, rows] of Object.entries(ins.tables)) {
+        if (key === 'workbook::vendor_totals' || key === 'workbook::vendor_spreads') continue;
+        const cols = Object.keys(rows[0] || {});
+        appendTable(key.replace(/[_:]+/g, ' '), rows, cols);
+      }
+    }
   }
 
   // helpers used in report

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,3 +66,26 @@ def test_generate_drafts_change_orders_only():
     assert summary["kind"] == "summary"
     assert summary["insights"]["total_change_orders"] == 1
     assert summary["insights"]["total_amount_sar"] == 150000.0
+
+
+def test_generate_drafts_no_budget_actual_pairs_returns_summary():
+    budget_actuals = [
+        BudgetActualRow(
+            project_id="P1",
+            period="2024-01",
+            cost_code="100-200",
+            category="Materials",
+            budget_sar=1000,
+            actual_sar=0,
+        )
+    ]
+    req = DraftRequest(
+        budget_actuals=budget_actuals,
+        change_orders=[],
+        vendor_map=[],
+        category_map=[],
+        config=ConfigModel(materiality_pct=0, materiality_amount_sar=0),
+    )
+    summary = generate_drafts(req)
+    assert summary["kind"] == "summary"
+    assert summary["insights"].get("row_count") == 1


### PR DESCRIPTION
## Summary
- Add highlights, cards, and tables to generic and change-order summaries so results contain clear financial insights
- Detect missing budget/actual pairs or immaterial variances and return the new summaries instead of cryptic output
- Render summary responses in the UI and add test coverage for the no-pair scenario

## Testing
- `ruff check .` *(fails: Multiple imports on one line)*
- `pytest` *(fails: No module named 'pdfplumber')*


------
https://chatgpt.com/codex/tasks/task_e_68ba5957f038832aaa1a0bd50c17b463