### PR TITLE
Enrich single-file track with structured analysis and insights

### DIFF
--- a/app/parsers/single_file_intake.py
+++ b/app/parsers/single_file_intake.py
@@ -6,6 +6,7 @@ from app.utils.diagnostics import DiagnosticContext
 from .procurement_pdf import parse_procurement_pdf
 import re
 import pdfplumber
+from app.services.insights import compute_procurement_insights
 
 # Column synonym maps for tolerant CSV/Excel intake
 MAP = {
@@ -101,13 +102,28 @@ def parse_single_file(filename: str, data: bytes) -> Dict[str, Any]:
       # Fallback: procurement summary extraction from existing PDF parser
       ps = parse_procurement_pdf(data)
       diag.step("parse_pdf_success", items=len(ps.get("items", [])))
-      return {"procurement_summary": ps, "diagnostics": diag.to_dict()}
+      analysis = compute_procurement_insights(ps.get("items", []))
+      return {
+        "procurement_summary": ps,
+        "analysis": analysis,
+        "economic_analysis": analysis,
+        "insights": analysis,
+        "diagnostics": diag.to_dict(),
+      }
     if name.endswith(".docx"):
       diag.step("parse_docx_start")
       doc = Document(io.BytesIO(data))
       text = "\n".join(p.text for p in doc.paragraphs)
       diag.step("parse_docx_success", paragraphs=len(doc.paragraphs))
-      return {"procurement_summary": {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}, "diagnostics": diag.to_dict()}
+      ps = {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}
+      analysis = compute_procurement_insights(ps.get("items", []))
+      return {
+        "procurement_summary": ps,
+        "analysis": analysis,
+        "economic_analysis": analysis,
+        "insights": analysis,
+        "diagnostics": diag.to_dict(),
+      }
     if name.endswith(".csv"):
       diag.step("parse_csv_start")
       try:
@@ -141,7 +157,15 @@ def parse_single_file(filename: str, data: bytes) -> Dict[str, Any]:
       diag.step("parse_text_start")
       text = data.decode("utf-8", errors="ignore")
       diag.step("parse_text_success", chars=len(text))
-      return {"procurement_summary": {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}, "diagnostics": diag.to_dict()}
+      ps = {"items":[{"item_code": None, "description": text[:2000], "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"}], "meta":{}}
+      analysis = compute_procurement_insights(ps.get("items", []))
+      return {
+        "procurement_summary": ps,
+        "analysis": analysis,
+        "economic_analysis": analysis,
+        "insights": analysis,
+        "diagnostics": diag.to_dict(),
+      }
 
     df = _map_cols(df)
     diag.step("columns_mapped", columns=list(df.columns))
@@ -155,4 +179,11 @@ def parse_single_file(filename: str, data: bytes) -> Dict[str, Any]:
       for _, r in df.head(50).iterrows():
         desc = " ".join(str(v) for v in r.to_dict().values() if pd.notna(v))[:2000]
         items.append({"item_code": None, "description": desc, "qty": None, "unit_price_sar": None, "amount_sar": None, "vendor_name": None, "doc_date": None, "source":"uploaded_file"})
-      return {"procurement_summary": {"items": items, "meta": {}}, "diagnostics": diag.to_dict()}
+      analysis = compute_procurement_insights(items)
+      return {
+        "procurement_summary": {"items": items, "meta": {}},
+        "analysis": analysis,
+        "economic_analysis": analysis,
+        "insights": analysis,
+        "diagnostics": diag.to_dict(),
+      }

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -29,16 +29,22 @@ async def from_file(file: UploadFile = File(...)):
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 
-        # Path B: No variance detected → show summary + economic analysis + insights
+        # Path B: No variance detected → show summary + analysis + insights
         ps = (parsed.get("procurement_summary") or {}).get("items") or []
         if ps:
-            analysis = compute_procurement_insights(ps)
+            analysis = (
+                parsed.get("analysis")
+                or parsed.get("economic_analysis")
+                or compute_procurement_insights(ps)
+            )
+            insights = parsed.get("insights") or analysis
             return {
                 "kind": "insights",
                 "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
                 "summary": {"items": ps},
+                "analysis": analysis,
                 "economic_analysis": analysis,
-                "insights": analysis,
+                "insights": insights,
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -10,6 +10,7 @@ def test_from_file_no_variance():
     assert r.status_code == 200
     j = r.json()
     assert j["kind"] == "insights"
-    assert "summary" in j and "economic_analysis" in j and "insights" in j
+    assert "summary" in j and "analysis" in j and "insights" in j
+    assert "economic_analysis" in j  # backwards compatibility
     assert "message" in j
     assert "budget-vs-actual" in j["message"].lower()

--- a/tests/test_singlefile_intake_diagnostics.py
+++ b/tests/test_singlefile_intake_diagnostics.py
@@ -18,3 +18,10 @@ def test_parse_single_file_returns_diagnostics():
     diag = resp["diagnostics"]
     assert diag.get("correlation_id")
     assert isinstance(diag.get("events"), list)
+
+
+def test_parse_single_file_no_budget_actual_returns_analysis():
+    df = pd.DataFrame({"vendor": ["ACME"], "amount": [100], "description": ["Item1"]})
+    b = _csv_bytes(df)
+    resp = parse_single_file("simple.csv", b)
+    assert "analysis" in resp and "insights" in resp


### PR DESCRIPTION
## Summary
- compute procurement insights whenever single-file parsing lacks budget/actual pairs
- expose analysis and insights through the unified `/drafts/from-file` endpoint
- test coverage for new analysis fields and backwards compatibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bad8416e04832ab7c88516a58db183