### PR TITLE
feat: classify and analyze single-file quotes

### DIFF
--- a/app/parsers/procurement_pdf.py
+++ b/app/parsers/procurement_pdf.py
@@ -4,6 +4,8 @@ import time
 from pdfminer.high_level import extract_text
 import pdfplumber
 import re
+import io
+from typing import Dict, Any, List
 
 # Fallback: detect unlabeled "qty unit_price total" rows
 ROW_TRIPLET = re.compile(
@@ -19,6 +21,28 @@ RE_QTY = re.compile(r'\b(?:QTY|Quantity)\s*[:=]?\s*(\d+(?:\.\d+)?)', re.I)
 RE_PRICE = re.compile(r'\b(?:Unit\s*Price|U\.?\s*Rate|Price)\s*(?:in\s*SAR)?\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
 RE_TOTAL = re.compile(r'\b(?:TOTAL|Amount|Grand\s*Total)\s*(?:in\s*SAR)?\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
 RE_VENDOR = re.compile(r'\b(?:Admark Creative|AL AZAL|Al Azal|Modern Furnishing|Woodwork Arts|Burj|OAKTREE|Oaktree|Alam)\b.*', re.I)
+
+# Totals / meta cues
+RE_SUBTOTAL = re.compile(r'\bsub\s*total\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
+RE_VAT_AMT = re.compile(r'\bvat[^\d%]*([0-9]{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
+RE_VAT_RATE = re.compile(r'\bvat\s*(\d{1,2}(?:\.\d+)?)[%]', re.I)
+RE_GRAND_TOTAL = re.compile(r'\bgrand\s*total\s*[:=]?\s*(\d{1,3}(?:[, ]\d{3})*(?:\.\d+)?)', re.I)
+RE_VALIDITY = re.compile(r'validity\s*(?:days)?\s*[:=]?\s*(\d+)', re.I)
+RE_PAYMENT = re.compile(r'payment\s*terms?\s*[:\-]?\s*(.+)', re.I)
+
+PR_CUES = ["item code", "qty/unit", "requested", "approved"]
+QUOTE_CUES = ["quotation", "quote #", "quote no", "grand total", "vat 15", "validity"]
+COMP_CUES = ["best price", "comparison"]
+
+UNIT_MAP = {
+    "sets": "unit",
+    "set": "unit",
+    "pcs": "unit",
+    "pcs.": "unit",
+    "pieces": "unit",
+    "nos": "unit",
+    "unit": "unit",
+}
 
 
 def _num(s: str) -> float | None:
@@ -47,14 +71,42 @@ def _extract_text_safe(pdf_bytes: bytes) -> str:
             return ""
 
 
+def _classify_page(txt: str) -> str:
+    lt = txt.lower()
+    if any(c in lt for c in QUOTE_CUES):
+        return "quote"
+    if any(c in lt for c in PR_CUES):
+        return "pr_boq"
+    if any(c in lt for c in COMP_CUES) or lt.count("vendor") > 1:
+        return "comparison"
+    return "unknown"
+
+
+def _norm_unit(txt: str | None) -> str | None:
+    if not txt:
+        return None
+    u = txt.strip().lower()
+    return UNIT_MAP.get(u, u)
+
+
 def parse_procurement_pdf(pdf_bytes: bytes) -> Dict[str, Any]:
     """
     Extract line items without inventing anything.
-    Returns {"items":[{item_code, description, qty, unit_price_sar, amount_sar, vendor_name, doc_date}], "meta":{...}}
+    Returns {"items":[{item_code, description, unit, qty, unit_price_sar, amount_sar, vendor_name, doc_date}], "meta":{...}}
     Missing fields stay None.
     """
     started = time.time()
     text = _extract_text_safe(pdf_bytes)
+
+    page_types: List[str] = []
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            for page in pdf.pages:
+                pt = page.extract_text() or ""
+                page_types.append(_classify_page(pt))
+    except Exception:
+        pass
+
     # Doc date / vendor (best-effort, no invention)
     date = None
     m = RE_DATE.search(text)
@@ -76,8 +128,6 @@ def parse_procurement_pdf(pdf_bytes: bytes) -> Dict[str, Any]:
         code_m = RE_ITEM.search(ch)
         item_code = code_m.group(1).strip() if code_m else None
 
-        # description: take the paragraph following the code line
-        # keep only what exists in the PDF (truncate excessive whitespace)
         desc_lines = [ln.strip() for ln in ch.splitlines() if ln.strip()]
         description = " ".join(desc_lines[:20])[:2000] if desc_lines else None
 
@@ -98,9 +148,15 @@ def parse_procurement_pdf(pdf_bytes: bytes) -> Dict[str, Any]:
         elif qty and unit_price:
             amount = round(qty * unit_price, 2)
 
+        unit = None
+        um = re.search(r'\b(SETS?|PCS|PIECES|NOS|UNIT|M2|M3)\b', ch, re.I)
+        if um:
+            unit = _norm_unit(um.group(0))
+
         items.append({
             "item_code": item_code,
             "description": description,
+            "unit": unit,
             "qty": qty,
             "unit_price_sar": unit_price,
             "amount_sar": amount,
@@ -146,4 +202,45 @@ def parse_procurement_pdf(pdf_bytes: bytes) -> Dict[str, Any]:
     if time.time() - started > 20 and not items:
         return {"items": [], "meta": {"vendor_name": vendor, "doc_date": date}}
 
-    return {"items": items, "meta": {"vendor_name": vendor, "doc_date": date}}
+    # Totals & meta extraction from whole text
+    subtotal = _num(RE_SUBTOTAL.search(text).group(1)) if RE_SUBTOTAL.search(text) else None
+    vat_amt = _num(RE_VAT_AMT.search(text).group(1)) if RE_VAT_AMT.search(text) else None
+    vat_rate = _num(RE_VAT_RATE.search(text).group(1)) if RE_VAT_RATE.search(text) else None
+    grand_total = _num(RE_GRAND_TOTAL.search(text).group(1)) if RE_GRAND_TOTAL.search(text) else None
+    validity = RE_VALIDITY.search(text)
+    validity_days = int(validity.group(1)) if validity else None
+    payment_m = RE_PAYMENT.search(text)
+    payment_terms = payment_m.group(1).strip() if payment_m else None
+
+    lt = text.lower()
+    delivery_included = None
+    if "delivery" in lt:
+        if re.search(r"delivery[^\n]*not\s+included", lt):
+            delivery_included = False
+        elif re.search(r"delivery[^\n]*included", lt):
+            delivery_included = True
+    hardware_included = None
+    if "hardware" in lt:
+        if re.search(r"hardware[^\n]*not\s+included", lt):
+            hardware_included = False
+        elif re.search(r"hardware[^\n]*included", lt):
+            hardware_included = True
+
+    meta = {
+        "vendor_name": vendor,
+        "doc_date": date,
+        "page_types": page_types,
+        "doc_type": max(page_types, key=page_types.count) if page_types else None,
+        "subtotal_amount_sar": subtotal,
+        "vat_amount_sar": vat_amt,
+        "vat_pct": vat_rate,
+        "grand_total_sar": grand_total,
+        "validity_days": validity_days,
+        "payment_terms": payment_terms,
+        "delivery_included": delivery_included,
+        "hardware_included": hardware_included,
+    }
+
+    if subtotal and vat_rate and not vat_amt:
+        meta["vat_amount_recalc_sar"] = round(subtotal * (vat_rate / 100.0), 2)
+    return {"items": items, "meta": meta}

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, UploadFile, File
 import asyncio
 from app.parsers.single_file_intake import parse_single_file
-from app.services.insights import compute_procurement_insights, compute_variance_insights
+from app.services.insights import (
+    compute_procurement_insights,
+    compute_variance_insights,
+    DEFAULT_BASKET,
+)
 
 router = APIRouter()
 
@@ -35,7 +39,7 @@ async def from_file(file: UploadFile = File(...)):
             analysis = (
                 parsed.get("analysis")
                 or parsed.get("economic_analysis")
-                or compute_procurement_insights(ps)
+                or compute_procurement_insights(ps, basket=DEFAULT_BASKET)
             )
             insights = parsed.get("insights") or analysis
             return {

--- a/tests/test_procurement_pdf.py
+++ b/tests/test_procurement_pdf.py
@@ -12,3 +12,43 @@ def test_triplet_fallback(monkeypatch):
     assert items[1]["qty"] == 2
     assert items[1]["unit_price_sar"] == 5000.0
     assert items[1]["amount_sar"] == 10000.0
+
+
+def test_quote_classification(monkeypatch):
+    text = (
+        "Quotation #123\n"
+        "Item Code D01\nQty 1\nUnit Price 100\nTotal 100\n"
+        "Subtotal 100\nVAT 15% 15\nGrand Total 115\n"
+        "Validity 30 days\nPayment terms: 50% advance\n"
+        "Delivery included\nHardware not included"
+    )
+
+    class DummyPage:
+        def __init__(self, t):
+            self.t = t
+
+        def extract_text(self):
+            return self.t
+
+    class DummyPDF:
+        def __init__(self, t):
+            self.pages = [DummyPage(t)]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr("app.parsers.procurement_pdf.extract_text", lambda *a, **k: text)
+    monkeypatch.setattr("app.parsers.procurement_pdf.pdfplumber.open", lambda *a, **k: DummyPDF(text))
+
+    result = parse_procurement_pdf(b"%PDF-1.4")
+    meta = result["meta"]
+    assert meta["doc_type"] == "quote"
+    assert meta["grand_total_sar"] == 115.0
+    assert meta["vat_pct"] == 15.0
+    assert meta["validity_days"] == 30
+    assert meta["payment_terms"] == "50% advance"
+    assert meta["delivery_included"] is True
+    assert meta["hardware_included"] is False


### PR DESCRIPTION
## Summary
- classify PDF pages as purchase requests, quotes, or comparisons and pull totals, VAT, and terms from text
- aggregate quote line items against a default D01–D04 basket to produce vendor TCO and price spreads
- test quote classification on procurement PDFs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bade3ccc14832a882ff33423fd2d31