### PR TITLE
Handle procurement pdf in single file API

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,22 +7,25 @@ from app.main import app
 @app.post("/single/generate")
 async def single_generate(file: UploadFile = File(...), bilingual: bool = Form(True)):
     b = await file.read()
-    from app.parsers.single_file import parse_single_file
+    from app.parsers.single_file_intake import parse_single_file
 
     parsed = parse_single_file(file.filename, b)
 
-    if parsed.get("mode") == "variance":
-        # Reuse existing variance -> drafts pipeline
+    report_type = parsed.get("report_type")
+    mode = parsed.get("mode")
+
+    if "variance_items" in parsed:
+        source_items = parsed.get("variance_items", [])
         items = []
-        for it in parsed["items"]:
+        for it in source_items:
             items.append(
                 {
                     "project_id": it.get("label"),
                     "period": None,
                     "category": None,
-                    "budget_sar": it["budget_sar"],
-                    "actual_sar": it["actual_sar"],
-                    "variance_sar": it["variance_sar"],
+                    "budget_sar": it.get("budget_sar"),
+                    "actual_sar": it.get("actual_sar"),
+                    "variance_sar": it.get("variance_sar"),
                     "variance_pct": it.get("variance_pct"),
                     "drivers": [],
                     "vendors": [],
@@ -31,10 +34,47 @@ async def single_generate(file: UploadFile = File(...), bilingual: bool = Form(T
             )
         return {"mode": "variance", "items": items}
 
-    if parsed.get("mode") == "procurement":
+    if mode == "variance" or report_type == "variance_insights":
+        items = []
+        for it in parsed.get("items", []):
+            items.append(
+                {
+                    "project_id": it.get("label"),
+                    "period": None,
+                    "category": None,
+                    "budget_sar": it.get("budget_sar"),
+                    "actual_sar": it.get("actual_sar"),
+                    "variance_sar": it.get("variance_sar"),
+                    "variance_pct": it.get("variance_pct"),
+                    "drivers": [],
+                    "vendors": [],
+                    "evidence_links": [],
+                }
+            )
+        return {"mode": "variance", "items": items}
+
+    if "procurement_summary" in parsed:
         from app.llm.procurement_draft import format_procurement_cards
 
-        cards = format_procurement_cards(parsed, bilingual=bilingual)
+        ps = parsed.get("procurement_summary", {})
+        meta = ps.get("meta", {}) if isinstance(ps, dict) else {}
+        payload = {
+            "items": ps.get("items", []),
+            "vendor_name": meta.get("vendor_name"),
+            "doc_date": meta.get("doc_date"),
+        }
+        cards = format_procurement_cards(payload, bilingual=bilingual)
+        return {"mode": "procurement", "cards": cards}
+
+    if mode == "procurement" or report_type == "procurement_summary":
+        from app.llm.procurement_draft import format_procurement_cards
+
+        payload = {
+            "items": parsed.get("items", []),
+            "vendor_name": parsed.get("vendor_name"),
+            "doc_date": parsed.get("doc_date"),
+        }
+        cards = format_procurement_cards(payload, bilingual=bilingual)
         return {"mode": "procurement", "cards": cards}
 
     # Fallback summary

--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -196,5 +196,11 @@ async def analyze_single_file(
                 "source": "Uploaded procurement file",
             }
         )
-    return {"report_type": "procurement_summary", "items": cards, "source": name}
+    return {
+        "report_type": "procurement_summary",
+        "items": cards,
+        "source": name,
+        "vendor_name": vendor,
+        "doc_date": date,
+    }
 

--- a/tests/test_single_generate_procurement.py
+++ b/tests/test_single_generate_procurement.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from app.main import app
+import app.api as _api  # noqa: F401 - ensure /single/generate route is registered
+
+
+def test_single_generate_returns_procurement_cards():
+    client = TestClient(app)
+    pdf_path = Path(__file__).resolve().parent.parent / "samples" / "procurement_example.pdf"
+    with pdf_path.open("rb") as f:
+        resp = client.post("/single/generate", files={"file": ("sample.pdf", f, "application/pdf")})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("mode") == "procurement"
+    assert isinstance(data.get("cards"), list)
+    assert len(data["cards"]) > 0


### PR DESCRIPTION
## Summary
- surface vendor and doc date in single-file procurement parser
- return procurement cards from `/single/generate` when a procurement PDF is uploaded
- add regression test for procurement PDF handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae47e94e8832a9073e401ae99ff55