### PR TITLE
Handle PDFs without budget data

### DIFF
--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from app.main import app, require_api_key
+import pathlib
+
+app.dependency_overrides[require_api_key] = lambda: None
+
+def test_pdf_no_variance():
+    client = TestClient(app)
+    pdf_path = pathlib.Path('samples/procurement_example.pdf')
+    files = {"file": (pdf_path.name, pdf_path.read_bytes(), "application/pdf")}
+    r = client.post("/drafts/from-file", files=files)
+    assert r.status_code == 200
+    j = r.json()
+    assert j["kind"] == "insights"
+    assert "summary" in j and "analysis" in j and "insights" in j
+    assert "message" in j and "budget-vs-actual" in j["message"].lower()


### PR DESCRIPTION
## Summary
- Ensure PDF uploads without budget data return human-readable summaries and insights
- Add test covering PDF fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baec598020832ab9dbdbdbafaee62c