### PR TITLE
Skip cards for single-file uploads without budget data

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -4,6 +4,7 @@ from app.parsers.single_file_intake import parse_single_file
 from app.services.insights import (
     compute_procurement_insights,
     compute_variance_insights,
+    summarize_procurement_lines,
     DEFAULT_BASKET,
 )
 
@@ -42,10 +43,11 @@ async def from_file(file: UploadFile = File(...)):
                 or compute_procurement_insights(ps, basket=DEFAULT_BASKET)
             )
             insights = parsed.get("insights") or analysis
+            summary = summarize_procurement_lines(ps)
             return {
                 "kind": "insights",
                 "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
-                "summary": {"items": ps},
+                "summary": summary,
                 "analysis": analysis,
                 "economic_analysis": analysis,
                 "insights": insights,

--- a/app/services/insights.py
+++ b/app/services/insights.py
@@ -306,6 +306,33 @@ def compute_procurement_insights(
     return analysis
 
 
+def summarize_procurement_lines(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a tiny summary for procurement lines.
+
+    This helper avoids returning the raw item cards in API responses when no
+    budget/actual pairs are detected. It computes lightweight highlights such as
+    total line count, distinct vendor count and aggregate amount if available.
+    """
+    vendors: set[str] = set()
+    total = 0.0
+    for it in items or []:
+        v = it.get("vendor_name") or it.get("vendor")
+        if v:
+            vendors.add(str(v))
+        try:
+            amt = float(it.get("amount_sar")) if it.get("amount_sar") is not None else None
+        except Exception:
+            amt = None
+        if amt is not None:
+            total += amt
+    highlights = [f"{len(items)} line(s) detected."]
+    if vendors:
+        highlights.append(f"{len(vendors)} vendor(s) present.")
+    if total:
+        highlights.append(f"Total amount ≈ {round(total, 2):,} SAR.")
+    return {"highlights": highlights}
+
+
 # --- Variance insights for Budget vs Actual ---
 def compute_variance_insights(variance_items: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Rollups for Budget vs Actual variance rows produced by the single-file track.

--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -1,0 +1,12 @@
+import pathlib
+import asyncio
+
+from app.parsers.single_file import analyze_single_file
+
+
+def test_analyze_single_file_discards_cards():
+    pdf_path = pathlib.Path('samples/procurement_example.pdf')
+    data = pdf_path.read_bytes()
+    res = asyncio.run(analyze_single_file(data, pdf_path.name))
+    assert "summary" in res and "analysis" in res and "insights" in res
+    assert "items" not in res.get("summary", {})

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -11,6 +11,7 @@ def test_from_file_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary" in j and "analysis" in j and "insights" in j
+    assert "items" not in j["summary"]
     assert "economic_analysis" in j  # backwards compatibility
     assert "message" in j
     assert "budget-vs-actual" in j["message"].lower()

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -13,4 +13,5 @@ def test_pdf_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary" in j and "analysis" in j and "insights" in j
+    assert "items" not in j["summary"]
     assert "message" in j and "budget-vs-actual" in j["message"].lower()


### PR DESCRIPTION
## Summary
- add summarizer for procurement lines so single-file uploads without budget/actual pairs return only highlights
- update `/drafts/from-file` and single-file parser to emit summary, analysis and insights without card items
- cover behaviour with tests ensuring summaries omit item cards

## Testing
- `ruff check app/routers/drafts.py app/services/insights.py app/parsers/single_file.py tests/test_pdf_no_variance_returns_summary_and_insights.py tests/test_from_file_no_variance_returns_summary_and_insights.py tests/test_analyze_single_file_no_cards.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf46a923c832a96d57c38262bcafd