### PR TITLE
Handle PDFs in single file track

### DIFF
--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from app.services.singlefile import process_single_file
+
+
+def test_pdf_produces_summary_and_insights():
+    data = Path('samples/procurement_example.pdf').read_bytes()
+    res = process_single_file('procurement_example.pdf', data)
+    assert res['mode'] == 'summary'
+    assert len(res.get('items', [])) > 0
+    assert isinstance(res.get('analysis'), dict)
+    assert isinstance(res.get('insights'), dict)


### PR DESCRIPTION
## Summary
- Support PDF uploads in `process_single_file`, extracting procurement lines or variances via `parse_single_file`
- Generate markdown reports for PDF-derived variance or procurement summaries
- Test PDF handling to ensure summary, analysis, and insights are produced

## Testing
- `ruff check app/services/singlefile.py tests/test_singlefile_pdf.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb01d79840832aba22af1553a28faa