### PR TITLE
Ensure single-file highlights and clearer PDF errors

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -44,6 +44,9 @@ async def from_file(file: UploadFile = File(...)):
             )
             insights = parsed.get("insights") or analysis
             summary = summarize_procurement_lines(ps)
+            highs = summary.get("highlights") or []
+            if highs and isinstance(insights, dict):
+                insights = {**insights, "highlights": highs}
             return {
                 "kind": "insights",
                 "message": "No budget-vs-actual data detected. Showing summary and insights instead.",

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -266,8 +266,10 @@ def process_single_file(
         )
         insights = parsed.get("insights") or analysis
         summary = summarize_procurement_lines(items)
-        md: List[str] = [f"### Single-File Summary — {filename}", ""]
         highs = summary.get("highlights") or []
+        if highs and isinstance(insights, dict):
+            insights = {**insights, "highlights": highs}
+        md: List[str] = [f"### Single-File Summary — {filename}", ""]
         if highs:
             md.append("#### Highlights")
             md.append("\n".join(f"- {h}" for h in highs))
@@ -277,6 +279,7 @@ def process_single_file(
             "items": items,
             "analysis": analysis,
             "economic_analysis": analysis,
+            "summary": summary,
             "insights": insights,
             "report_markdown": "\n".join(md).strip(),
             "diagnostics": parsed.get("diagnostics", {}),

--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -376,8 +376,14 @@
     setStatus('Calling model…');
     try {
       const res = await fetch('/drafts/from-file', { method:'POST', body: fd });
-      if (!res.ok) throw new Error(await res.text());
-      const data = await res.json();
+      const txt = await res.text();
+      let data = {};
+      try { data = JSON.parse(txt); } catch (_) {}
+      if (!res.ok || (data && data.error)) {
+        setStatus((data && data.error) ? data.error : `Request failed (HTTP ${res.status})`);
+        if (data && data.diagnostics) { renderDiagnostics(data.diagnostics); }
+        return;
+      }
       clearReport();
 
       if (data.variance_items && data.variance_items.length) {
@@ -405,7 +411,7 @@
 
       setStatus('No budget-vs-actual data detected.');
     } catch (e) {
-      setStatus('Load failed');
+      setStatus(`Load failed: ${e.message || e.toString()}`);
       showError(e.message || e.toString());
     }
   }


### PR DESCRIPTION
## Summary
- Preserve workbook highlights by merging summary info into returned insights
- Attach summary details in single-file PDF handling and expose highlights to UI
- Improve single-file UI error handling to show server messages instead of generic load failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb07f53e7c832a84fd6842ff3ec8f5