### PR TITLE
Ensure procurement summaries render for PDF uploads

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -35,7 +35,8 @@ async def from_file(file: UploadFile = File(...)):
             }
 
         # Path B: No variance detected → show summary + analysis + insights
-        ps = (parsed.get("procurement_summary") or {}).get("items") or []
+        ps_full = parsed.get("procurement_summary") or {}
+        ps = ps_full.get("items") or []
         if ps:
             analysis = (
                 parsed.get("analysis")
@@ -54,6 +55,7 @@ async def from_file(file: UploadFile = File(...)):
                 "analysis": analysis,
                 "economic_analysis": analysis,
                 "insights": insights,
+                "procurement_summary": ps_full,
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -23,13 +23,6 @@ async function generateFromSingleFile() {
     return;
   }
   // NEW: Insights fallback (single-file track with no B/A and no recognizable line items)
-  if (data && (data.kind === "insights" || data.mode === "insights")) {
-    renderInsights(data.insights || {});
-    if (data.message) renderNotice(data.message);
-    setStatus && setStatus('Done');
-    return;
-  }
-
   const variance = (data.variance_items || []);
   const hasVariance = Array.isArray(variance) && variance.length > 0;
   const procurement = (data.procurement_summary && data.procurement_summary.items)
@@ -40,7 +33,10 @@ async function generateFromSingleFile() {
     renderVarianceDraftCards(variance);
   } else if (hasProcurement) {
     if (data.message) renderNotice(data.message);
-    renderProcurementSummary({ items: procurement, insights: data.insights || {} });
+    renderProcurementSummary({ items: procurement, insights: data.insights || data.analysis || {} });
+  } else if (data && (data.kind === "insights" || data.mode === "insights")) {
+    renderInsights(data.insights || {});
+    if (data.message) renderNotice(data.message);
   } else {
     renderSingleFileError('No budget/actuals found. Showing file-level insights instead.');
   }


### PR DESCRIPTION
## Summary
- include full `procurement_summary` in single-file insights API response
- prioritize procurement summaries before generic insights in single-file UI

## Testing
- `pytest -q`
- `ruff check app/routers/drafts.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e7c83e0832a95c5b783ac5af196