### PR TITLE
Expose procurement summary in insights responses

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -51,11 +51,14 @@ async def from_file(file: UploadFile = File(...)):
             return {
                 "kind": "insights",
                 "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
+                "procurement_summary": {
+                    "items": ps,
+                    "meta": ps_full.get("meta", {}),
+                },
                 "summary": summary,
                 "analysis": analysis,
                 "economic_analysis": analysis,
                 "insights": insights,
-                "procurement_summary": ps_full,
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -35,8 +35,13 @@ async function generateFromSingleFile() {
     if (data.message) renderNotice(data.message);
     renderProcurementSummary({ items: procurement, insights: data.insights || data.analysis || {} });
   } else if (data && (data.kind === "insights" || data.mode === "insights")) {
+    const ps = (data.procurement_summary && data.procurement_summary.items) ? data.procurement_summary.items : [];
+    if (ps.length) {
+      if (data.message) renderNotice(data.message);
+      renderProcurementSummary({ items: ps, insights: data.insights || {} });
+    }
     renderInsights(data.insights || {});
-    if (data.message) renderNotice(data.message);
+    setStatus && setStatus('Done');
   } else {
     renderSingleFileError('No budget/actuals found. Showing file-level insights instead.');
   }


### PR DESCRIPTION
## Summary
- Include procurement summary items and meta in insights response when no variance items detected
- Render procurement summaries alongside insights in UI when available

## Testing
- `pytest`
- `ruff check app/routers/drafts.py`
- `mypy app/routers/drafts.py` *(fails: Argument 1 to "float" has incompatible type "Any | None"; expected "str | Buffer | SupportsFloat | SupportsIndex")*


------
https://chatgpt.com/codex/tasks/task_e_68bb41da1344832a8c860746c5d39c53