### PR TITLE
Add LLM summary for single-file uploads without variance

### DIFF
--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -10,6 +10,7 @@ from app.services.insights import (
     summarize_procurement_lines,
     DEFAULT_BASKET,
 )
+from app.gpt_client import summarize_financials
 
 RE_MONEY = re.compile(r"(?<![\d.])(?:SAR|SR|ر\.س)?\s*([0-9]{1,3}(?:[,0-9]{0,3})*(?:\.[0-9]{1,2})?)", re.I)
 RE_DATE  = re.compile(r"(20\d{2}[/-]\d{1,2}[/-]\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]20\d{2})")
@@ -202,11 +203,13 @@ async def analyze_single_file(
         )
     analysis = compute_procurement_insights(cards, basket=DEFAULT_BASKET)
     summary = summarize_procurement_lines(cards)
+    summary_text = summarize_financials(summary, analysis)
     return {
         "report_type": "procurement_summary",
         "summary": summary,
         "analysis": analysis,
         "insights": analysis,
+        "summary_text": summary_text,
         "source": name,
         "vendor_name": vendor,
         "doc_date": date,

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -7,6 +7,7 @@ from app.services.insights import (
     summarize_procurement_lines,
     DEFAULT_BASKET,
 )
+from app.gpt_client import summarize_financials
 
 router = APIRouter()
 
@@ -48,6 +49,7 @@ async def from_file(file: UploadFile = File(...)):
             highs = summary.get("highlights") or []
             if highs and isinstance(insights, dict):
                 insights = {**insights, "highlights": highs}
+            summary_text = summarize_financials(summary, insights if isinstance(insights, dict) else {})
             return {
                 "kind": "insights",
                 "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
@@ -59,6 +61,7 @@ async def from_file(file: UploadFile = File(...)):
                 "analysis": analysis,
                 "economic_analysis": analysis,
                 "insights": insights,
+                "summary_text": summary_text,
                 "diagnostics": parsed.get("diagnostics", {}),
             }
 

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -16,6 +16,7 @@ from app.services.insights import (
     compute_variance_insights,
     summarize_procurement_lines,
 )
+from app.gpt_client import summarize_financials
 from app.parsers.single_file_intake import parse_single_file
 
 
@@ -269,6 +270,7 @@ def process_single_file(
         highs = summary.get("highlights") or []
         if highs and isinstance(insights, dict):
             insights = {**insights, "highlights": highs}
+        summary_text = summarize_financials(summary, insights if isinstance(insights, dict) else {})
         md: List[str] = [f"### Single-File Summary — {filename}", ""]
         if highs:
             md.append("#### Highlights")
@@ -281,6 +283,7 @@ def process_single_file(
             "economic_analysis": analysis,
             "summary": summary,
             "insights": insights,
+            "summary_text": summary_text,
             "report_markdown": "\n".join(md).strip(),
             "diagnostics": parsed.get("diagnostics", {}),
         }

--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -9,4 +9,5 @@ def test_analyze_single_file_discards_cards():
     data = pdf_path.read_bytes()
     res = asyncio.run(analyze_single_file(data, pdf_path.name))
     assert "summary" in res and "analysis" in res and "insights" in res
+    assert isinstance(res.get("summary_text"), str)
     assert "items" not in res.get("summary", {})

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -11,6 +11,7 @@ def test_from_file_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary" in j and "analysis" in j and "insights" in j
+    assert isinstance(j.get("summary_text"), str)
     assert "items" not in j["summary"]
     assert "economic_analysis" in j  # backwards compatibility
     assert "message" in j

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -13,5 +13,6 @@ def test_pdf_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary" in j and "analysis" in j and "insights" in j
+    assert isinstance(j.get("summary_text"), str)
     assert "items" not in j["summary"]
     assert "message" in j and "budget-vs-actual" in j["message"].lower()

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -9,3 +9,4 @@ def test_pdf_produces_summary_and_insights():
     assert len(res.get('items', [])) > 0
     assert isinstance(res.get('analysis'), dict)
     assert isinstance(res.get('insights'), dict)
+    assert isinstance(res.get('summary_text'), str)


### PR DESCRIPTION
## Summary
- add `summarize_financials` in `gpt_client` to generate AI-based summaries with deterministic fallback
- call the new summarizer in single-file routes and services when no budget/actual data is found
- extend tests to expect `summary_text` for single-file summaries

## Testing
- `pytest`
- `ruff check .` *(fails: E401 Multiple imports, etc.)*
- `mypy app` *(fails: 62 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ad7c8f0832aa21d76bf05405d25