### PR TITLE
Streamline LLM summary for variance-free single-file uploads

### DIFF
--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -1,6 +1,7 @@
 
 import os
-from typing import Tuple
+import json
+from typing import Tuple, Dict, Any
 
 from .schemas import VarianceItem, ConfigModel
 from .prompt_contract import (
@@ -63,3 +64,62 @@ def generate_draft(v: VarianceItem, cfg: ConfigModel) -> Tuple[str, str]:
         return text, ""
     except Exception:
         return _fallback_text(v, cfg)
+
+
+def summarize_financials(summary: Dict[str, Any], analysis: Dict[str, Any]) -> Dict[str, str]:
+    """Summarize procurement data with optional AI, returning text fields.
+
+    The helper asks ChatGPT for three short sections: ``summary``,
+    ``analysis`` and ``insights``. When the API is unavailable we fall back
+    to deterministic text extracted from any available highlights.
+    """
+
+    highlights: list[str] = []
+    if isinstance(summary, dict):
+        highlights.extend(summary.get("highlights", []))
+    if isinstance(analysis, dict):
+        highlights.extend(analysis.get("highlights", []))
+
+    fallback = {
+        "summary": " ".join(highlights).strip() or "No summary available.",
+        "analysis": "No financial analysis available.",
+        "insights": "No financial insights available.",
+    }
+
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        return fallback
+    try:
+        from openai import OpenAI
+
+        timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
+        retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+        client = OpenAI(api_key=api_key, timeout=timeout, max_retries=retries)
+        prompt = (
+            "You are a financial analyst. Using the data below, respond with a JSON "
+            "object containing short strings for keys 'summary', 'analysis', and "
+            "'insights'.\n\n"
+            f"Highlights: {', '.join(highlights)}\n"
+            f"Analysis: {json.dumps(analysis, default=str)[:4000]}"
+        )
+        messages = [
+            {"role": "system", "content": "You are a helpful financial analysis assistant."},
+            {"role": "user", "content": prompt},
+        ]
+        resp = client.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-5.1-mini"),
+            messages=messages,  # type: ignore[arg-type]
+            timeout=timeout,
+        )
+        text = (resp.choices[0].message.content or "").strip()
+        try:
+            data = json.loads(text)
+            return {
+                "summary": str(data.get("summary", fallback["summary"])),
+                "analysis": str(data.get("analysis", fallback["analysis"])),
+                "insights": str(data.get("insights", fallback["insights"])),
+            }
+        except Exception:
+            return fallback
+    except Exception:
+        return fallback

--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -10,6 +10,7 @@ from app.services.insights import (
     summarize_procurement_lines,
     DEFAULT_BASKET,
 )
+from app.gpt_client import summarize_financials
 
 RE_MONEY = re.compile(r"(?<![\d.])(?:SAR|SR|ر\.س)?\s*([0-9]{1,3}(?:[,0-9]{0,3})*(?:\.[0-9]{1,2})?)", re.I)
 RE_DATE  = re.compile(r"(20\d{2}[/-]\d{1,2}[/-]\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]20\d{2})")
@@ -202,13 +203,5 @@ async def analyze_single_file(
         )
     analysis = compute_procurement_insights(cards, basket=DEFAULT_BASKET)
     summary = summarize_procurement_lines(cards)
-    return {
-        "report_type": "procurement_summary",
-        "summary": summary,
-        "analysis": analysis,
-        "insights": analysis,
-        "source": name,
-        "vendor_name": vendor,
-        "doc_date": date,
-    }
+    return summarize_financials(summary, analysis)
 

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -7,6 +7,7 @@ from app.services.insights import (
     summarize_procurement_lines,
     DEFAULT_BASKET,
 )
+from app.gpt_client import summarize_financials
 
 router = APIRouter()
 
@@ -48,19 +49,9 @@ async def from_file(file: UploadFile = File(...)):
             highs = summary.get("highlights") or []
             if highs and isinstance(insights, dict):
                 insights = {**insights, "highlights": highs}
-            return {
-                "kind": "insights",
-                "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
-                "procurement_summary": {
-                    "items": ps,
-                    "meta": ps_full.get("meta", {}),
-                },
-                "summary": summary,
-                "analysis": analysis,
-                "economic_analysis": analysis,
-                "insights": insights,
-                "diagnostics": parsed.get("diagnostics", {}),
-            }
+            return summarize_financials(
+                summary, insights if isinstance(insights, dict) else {}
+            )
 
         return {
             "error": "We couldn’t find budget/actuals or recognizable procurement lines in this file.",

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -16,6 +16,7 @@ from app.services.insights import (
     compute_variance_insights,
     summarize_procurement_lines,
 )
+from app.gpt_client import summarize_financials
 from app.parsers.single_file_intake import parse_single_file
 
 
@@ -269,21 +270,9 @@ def process_single_file(
         highs = summary.get("highlights") or []
         if highs and isinstance(insights, dict):
             insights = {**insights, "highlights": highs}
-        md: List[str] = [f"### Single-File Summary — {filename}", ""]
-        if highs:
-            md.append("#### Highlights")
-            md.append("\n".join(f"- {h}" for h in highs))
-            md.append("")
-        return {
-            "mode": "summary",
-            "items": items,
-            "analysis": analysis,
-            "economic_analysis": analysis,
-            "summary": summary,
-            "insights": insights,
-            "report_markdown": "\n".join(md).strip(),
-            "diagnostics": parsed.get("diagnostics", {}),
-        }
+        return summarize_financials(
+            summary, insights if isinstance(insights, dict) else {}
+        )
 
     with DiagnosticContext(file_name=filename, file_size=len(data)) as diag:
         diag.step("singlefile_start", filename=filename)

--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -8,5 +8,5 @@ def test_analyze_single_file_discards_cards():
     pdf_path = pathlib.Path('samples/procurement_example.pdf')
     data = pdf_path.read_bytes()
     res = asyncio.run(analyze_single_file(data, pdf_path.name))
-    assert "summary" in res and "analysis" in res and "insights" in res
-    assert "items" not in res.get("summary", {})
+    assert set(res.keys()) == {"summary", "analysis", "insights"}
+    assert all(isinstance(res[k], str) for k in res)

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -9,9 +9,5 @@ def test_from_file_no_variance():
     r = client.post("/drafts/from-file", files=files)
     assert r.status_code == 200
     j = r.json()
-    assert j["kind"] == "insights"
-    assert "summary" in j and "analysis" in j and "insights" in j
-    assert "items" not in j["summary"]
-    assert "economic_analysis" in j  # backwards compatibility
-    assert "message" in j
-    assert "budget-vs-actual" in j["message"].lower()
+    assert set(j.keys()) == {"summary", "analysis", "insights"}
+    assert all(isinstance(j[k], str) for k in j)

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -11,7 +11,5 @@ def test_pdf_no_variance():
     r = client.post("/drafts/from-file", files=files)
     assert r.status_code == 200
     j = r.json()
-    assert j["kind"] == "insights"
-    assert "summary" in j and "analysis" in j and "insights" in j
-    assert "items" not in j["summary"]
-    assert "message" in j and "budget-vs-actual" in j["message"].lower()
+    assert set(j.keys()) == {"summary", "analysis", "insights"}
+    assert all(isinstance(j[k], str) for k in j)

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -5,7 +5,5 @@ from app.services.singlefile import process_single_file
 def test_pdf_produces_summary_and_insights():
     data = Path('samples/procurement_example.pdf').read_bytes()
     res = process_single_file('procurement_example.pdf', data)
-    assert res['mode'] == 'summary'
-    assert len(res.get('items', [])) > 0
-    assert isinstance(res.get('analysis'), dict)
-    assert isinstance(res.get('insights'), dict)
+    assert set(res.keys()) == {"summary", "analysis", "insights"}
+    assert all(isinstance(res[k], str) for k in res)


### PR DESCRIPTION
## Summary
- revise `summarize_financials` to produce separate `summary`, `analysis`, and `insights` strings with deterministic fallback
- in single-file parser, service, and route return only these text fields when no budget/actual variance is detected
- adjust tests to expect streamlined outputs without cards or additional metadata

## Testing
- `pytest`
- `ruff check .` *(fails: E401 Multiple imports on one line, etc.)*
- `mypy app` *(fails: 62 errors, e.g., incompatible types in `insights.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ad7c8f0832aa21d76bf05405d25