### PR TITLE
Streamline single-file summaries and UI diagnostics

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -136,17 +136,6 @@ def _summarize_change_orders(change_orders: List[ChangeOrderRow], cat_lu: Dict[s
             ],
             "top_change_orders_by_amount": top,
             "highlights": highlights,
-            "cards": [
-                {"title": "Total amount", "value_sar": round(total, 2)},
-                {"title": "Change orders", "value": count},
-            ],
-            "tables": {
-                "totals_by_category": [
-                    {"category": k, "total_amount_sar": round(v, 2)}
-                    for k, v in sorted(by_cat.items(), key=lambda x: -x[1])
-                ],
-                "top_change_orders_by_amount": top,
-            },
         },
     }
 
@@ -234,11 +223,6 @@ def _summarize_generic_rows(rows: List[Dict[str, Any]], label: str = "rows") -> 
             "top_rows_by_amount": top,
             "label": label,
             "highlights": highlights,
-            "cards": [{"title": "Total", "value": round(total, 2)}],
-            "tables": {
-                "totals_by_group": totals_by_group,
-                "top_rows_by_amount": top,
-            },
         },
     }
 

--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -381,7 +381,6 @@
       try { data = JSON.parse(txt); } catch (_) {}
       if (!res.ok || (data && data.error)) {
         setStatus((data && data.error) ? data.error : `Request failed (HTTP ${res.status})`);
-        if (data && data.diagnostics) { renderDiagnostics(data.diagnostics); }
         return;
       }
       clearReport();

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -9,12 +9,10 @@ async function generateFromSingleFile() {
   try { data = await resp.json(); } catch (_) {}
   if (!resp.ok) {
     renderSingleFileError((data && data.error) ? data.error : `Request failed (HTTP ${resp.status})`);
-    if (data && data.diagnostics) { renderDiagnostics(data.diagnostics); }
     return;
   }
   if (data && data.error) {
     renderSingleFileError(data.error);
-    if (data.diagnostics) { renderDiagnostics(data.diagnostics); }
     return;
   }
   if (data && (data.kind === "quote_compare" || data.mode === "quote_compare")) {
@@ -44,9 +42,6 @@ async function generateFromSingleFile() {
     setStatus && setStatus('Done');
   } else {
     renderSingleFileError('No budget/actuals found. Showing file-level insights instead.');
-  }
-  if (data && data.diagnostics) {
-    renderDiagnostics(data.diagnostics);
   }
 }
 
@@ -225,64 +220,7 @@ function renderNotice(msg) {
   }
 }
 
-function renderDiagnostics(diag) {
-  const container = document.getElementById('results') || document.body;
-  const section = document.createElement('section');
-  section.className = 'diagnostics';
-
-  const details = document.createElement('details');
-  details.open = false;
-  const summary = document.createElement('summary');
-  summary.textContent = 'Diagnostics';
-  details.appendChild(summary);
-
-  const meta = document.createElement('div');
-  meta.innerHTML = `
-    <div style="margin:8px 0;">
-      <strong>Correlation ID:</strong> <code>${escapeHtml(diag.correlation_id || '')}</code><br/>
-      <strong>Duration:</strong> ${Number(diag.duration_ms||0)} ms<br/>
-      <strong>Sheets/Steps:</strong> ${Array.isArray(diag.events) ? diag.events.length : 0} events,
-      <strong>Warnings:</strong> ${Array.isArray(diag.warnings) ? diag.warnings.length : 0}
-    </div>
-  `;
-  details.appendChild(meta);
-
-  if (Array.isArray(diag.warnings) && diag.warnings.length) {
-    const w = document.createElement('div');
-    w.innerHTML = `<strong>Warnings</strong>`;
-    const ul = document.createElement('ul');
-    diag.warnings.forEach(wrn => {
-      const li = document.createElement('li');
-      li.textContent = `[${wrn.code}] ${wrn.message || ''}`;
-      ul.appendChild(li);
-    });
-    w.appendChild(ul);
-    details.appendChild(w);
-  }
-
-  const pre = document.createElement('pre');
-  pre.style.whiteSpace = 'pre-wrap';
-  const json = JSON.stringify(diag, null, 2);
-  pre.textContent = json;
-
-  const bar = document.createElement('div');
-  bar.style.display = 'flex';
-  bar.style.gap = '8px';
-  bar.style.margin = '8px 0';
-
-  const copyBtn = document.createElement('button');
-  copyBtn.textContent = 'Copy diagnostics JSON';
-  copyBtn.onclick = async () => {
-    try { await navigator.clipboard.writeText(json); toast('Copied diagnostics'); }
-    catch (e) { toast('Copy failed'); }
-  };
-  bar.appendChild(copyBtn);
-
-  details.appendChild(bar);
-  details.appendChild(pre);
-  section.appendChild(details);
-  container.appendChild(section);
-}
+// diagnostics removed
 
 function escapeHtml(s) {
   return String(s)
@@ -319,9 +257,6 @@ function renderResult(payload) {
     payload.insights.highlights.forEach(t => { const li = document.createElement('li'); li.textContent = t; ul.appendChild(li); });
     box.appendChild(ul);
     root.appendChild(box);
-  }
-  if (payload.diagnostics) {
-    renderDiagnostics(payload.diagnostics);
   }
 }
 

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -104,10 +104,6 @@
         <summary>Error details</summary>
         <pre id="error-stack"></pre>
       </details>
-      <details id="diag-details" style="display:none;margin-top:8px;">
-        <summary>Diagnostics</summary>
-        <pre id="diag-text"></pre>
-      </details>
     </div>
 
     <div class="card">
@@ -143,24 +139,11 @@
     pre.textContent = msg;
   };
   const clearErrorDetails = () => showErrorDetails(null);
-  const renderDiagnostics = diag => {
-    const det = $('diag-details');
-    const pre = $('diag-text');
-    if (!det || !pre) return;
-    if (!diag) {
-      det.style.display = 'none';
-      pre.textContent = '';
-      return;
-    }
-    det.style.display = 'block';
-    det.open = true;
-    pre.textContent = typeof diag === 'string' ? diag : JSON.stringify(diag, null, 2);
-  };
   const setStatus = (msg, cls='') => {
     const s = $('status');
     s.textContent = msg;
     s.className = 'status ' + cls;
-    if (cls !== 'err') { clearErrorDetails(); renderDiagnostics(null); }
+    if (cls !== 'err') { clearErrorDetails(); }
   };
   const setBar = pct => { $('bar').style.width = Math.max(0, Math.min(100, pct)) + '%'; };
   window.addEventListener('error', e => {
@@ -401,7 +384,6 @@
         showErrorDetails(txt);
         let parsed;
         try { parsed = JSON.parse(txt); } catch (_) {}
-        renderDiagnostics(parsed && parsed.diagnostics ? parsed.diagnostics : parsed);
         setBar(0); $('btnSingle').disabled = false; return;
       }
       const result = await resp.json();
@@ -409,12 +391,10 @@
         setStatus(result.error, 'err'); setBar(0); $('btnSingle').disabled = false;
         $('result').textContent = result.error;
         showErrorDetails(result);
-        renderDiagnostics(result.diagnostics);
         return;
       }
       setStatus('Done', 'ok'); setBar(100);
       renderFromFileResult(result);
-      if (result.diagnostics) renderDiagnostics(result.diagnostics);
     } catch (err) {
       setStatus(String(err && err.message ? err.message : err), 'err'); setBar(0);
       showErrorDetails(err);
@@ -500,14 +480,12 @@
         showErrorDetails(txt);
         let parsed;
         try { parsed = JSON.parse(txt); } catch (_) {}
-        renderDiagnostics(parsed && parsed.diagnostics ? parsed.diagnostics : parsed);
         setBar(0); $('btnGen').disabled=false; return;
       }
 
       const data = await resp.json();
       setStatus('Done', 'ok'); setBar(100);
       renderResult(data);
-      if (data.diagnostics) renderDiagnostics(data.diagnostics);
     } catch (err) {
       setStatus(String(err && err.message ? err.message : err), 'err');
       setBar(0);

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -5,8 +5,8 @@ from app.services.singlefile import process_single_file
 def test_pdf_produces_summary_and_insights():
     data = Path('samples/procurement_example.pdf').read_bytes()
     res = process_single_file('procurement_example.pdf', data)
-    assert res['mode'] == 'summary'
-    assert len(res.get('items', [])) > 0
+    assert 'summary' in res and isinstance(res['summary'], dict)
     assert isinstance(res.get('analysis'), dict)
     assert isinstance(res.get('insights'), dict)
+    assert 'items' not in res
     assert isinstance(res.get('summary_text'), str)


### PR DESCRIPTION
## Summary
- Drop card/table structures from generic and change-order summaries
- Return only summary, analysis, insights, and text when single-file uploads lack budget/actual pairs
- Remove diagnostics panel and references from UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb58e1facc832a9daba42a525778c8