### PR TITLE
Single-file track: text-only insights path

### DIFF
--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -32,10 +32,9 @@ async def from_file(file: UploadFile = File(...)):
                 "kind": "variance",
                 "variance_items": variance,
                 "insights": compute_variance_insights(variance),
-                "diagnostics": parsed.get("diagnostics", {}),
             }
 
-        # Path B: No variance detected → show summary + analysis + insights
+        # Path B: No variance detected → return summary + analysis + insights ONLY (no cards/diagnostics)
         ps_full = parsed.get("procurement_summary") or {}
         ps = ps_full.get("items") or []
         if ps:
@@ -52,22 +51,14 @@ async def from_file(file: UploadFile = File(...)):
             summary_text = summarize_financials(summary, insights if isinstance(insights, dict) else {})
             return {
                 "kind": "insights",
-                "message": "No budget-vs-actual data detected. Showing summary and insights instead.",
-                "procurement_summary": {
-                    "items": ps,
-                    "meta": ps_full.get("meta", {}),
-                },
                 "summary": summary,
                 "analysis": analysis,
-                "economic_analysis": analysis,
                 "insights": insights,
                 "summary_text": summary_text,
-                "diagnostics": parsed.get("diagnostics", {}),
             }
 
         return {
             "error": "We couldn’t find budget/actuals or recognizable procurement lines in this file.",
-            "diagnostics": parsed.get("diagnostics", {}),
         }
     except Exception as e:
         return {"error": str(e)}

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -635,11 +635,7 @@
       `;
       box.appendChild(div);
     });
-    if (insights && (insights.totals_per_vendor || insights.top_lines_by_amount)) {
-      const pre = document.createElement('pre');
-      pre.textContent = JSON.stringify(insights, null, 2);
-      box.appendChild(pre);
-    }
+    // (Raw JSON dump removed to keep UI concise)
   }
 
   function renderInsights(ins) {

--- a/app/ui.html
+++ b/app/ui.html
@@ -19,10 +19,6 @@
   <label><input id="opt_bilingual" type="checkbox" checked /> Bilingual</label>
   <label><input id="opt_nospec" type="checkbox" checked /> No speculation</label>
   <button onclick="generateFromSingleFile()">Analyze</button>
-  <details id="diag" style="margin-top:8px;">
-    <summary>Diagnostics</summary>
-    <div id="diag-body" class="mono small"></div>
-  </details>
   <div id="result_box" style="margin-top:20px; white-space:pre-wrap;"></div>
 </body>
 </html>

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -13,6 +13,5 @@ def test_from_file_no_variance():
     assert "summary" in j and "analysis" in j and "insights" in j
     assert isinstance(j.get("summary_text"), str)
     assert "items" not in j["summary"]
-    assert "economic_analysis" in j  # backwards compatibility
-    assert "message" in j
-    assert "budget-vs-actual" in j["message"].lower()
+    assert "economic_analysis" not in j
+    assert "message" not in j

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -15,4 +15,4 @@ def test_pdf_no_variance():
     assert "summary" in j and "analysis" in j and "insights" in j
     assert isinstance(j.get("summary_text"), str)
     assert "items" not in j["summary"]
-    assert "message" in j and "budget-vs-actual" in j["message"].lower()
+    assert "message" not in j


### PR DESCRIPTION
## Summary
- Return only summary/analysis/insights/summary_text when no variance is present in single-file uploads
- Strip diagnostics UI and card rendering for single-file insights path and remove raw JSON dumps
- Adjust tests for new minimal response

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb5f91fcb0832a82d6da00e73ebd70