### PR TITLE
Always send single-file uploads to ChatGPT and return three text blocks

### DIFF
--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -11,4 +11,4 @@ async def analyze_single_file(
 ) -> Dict[str, Any]:
     """Analyze a single file by delegating to ChatGPT for insights."""
     res = process_single_file(name, data)
-    return {"report_type": "summary", "summary": {}, **res, "source": name}
+    return {"report_type": "summary", **res, "source": name}

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -17,6 +17,6 @@ def process_single_file(filename: str, data: bytes, *_, **__) -> Dict[str, Any]:
     llm_out = llm_financial_summary({"raw_text": text})
     return {
         "summary_text": llm_out.get("summary_text", ""),
-        "analysis": {"text": llm_out.get("analysis_text", "")},
-        "insights": {"text": llm_out.get("insights_text", "")},
+        "analysis_text": llm_out.get("analysis_text", ""),
+        "insights_text": llm_out.get("insights_text", ""),
     }

--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -403,16 +403,14 @@
       }
       const textOnly = (
         data.kind === 'insights' || data.mode === 'insights' ||
-        data.summary_text ||
-        (data.analysis && (data.analysis.text || data.analysis)) ||
-        (data.insights && (data.insights.text || data.insights))
+        data.summary_text || data.analysis_text || data.insights_text
       );
       if (textOnly) {
         hardRemoveWorkbookInsights();
         renderSummaryAnalysisInsightsOnly({
           summary_text: data.summary_text || '',
-          analysis: (data.analysis && (data.analysis.text || data.analysis)) || data.economic_analysis || '',
-          insights: (data.insights && (data.insights.text || data.insights)) || ''
+          analysis_text: data.analysis_text || '',
+          insights_text: data.insights_text || ''
         });
         setStatus('Done');
         return;
@@ -514,13 +512,11 @@
 
   function renderSummaryAnalysisInsightsOnly(payload) {
     const root = ensureSection('report-root', '');
-    const { summary_text, analysis = {}, insights = {} } = payload || {};
-    const analysisText = typeof analysis === 'string' ? analysis : (analysis && analysis.text) || '';
-    const insightsText = typeof insights === 'string' ? insights : (insights && insights.text) || '';
+    const { summary_text = '', analysis_text = '', insights_text = '' } = payload || {};
     const blocks = []
       .concat(summary_text ? ['Summary', summary_text] : [])
-      .concat(analysisText ? ['Financial analysis', analysisText] : [])
-      .concat(insightsText ? ['Financial insights', insightsText] : []);
+      .concat(analysis_text ? ['Financial analysis', analysis_text] : [])
+      .concat(insights_text ? ['Financial insights', insights_text] : []);
     const card = document.createElement('div');
     card.className = 'card';
     card.textContent = blocks.join('\n\n');

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -32,10 +32,9 @@ async function generateFromSingleFile() {
     // Text-only: summary, analysis, insights (number-supported). No cards/tables/diagnostics.
     hardRemoveWorkbookInsights();
     renderSummaryAnalysisInsightsOnly({
-      summary: data.summary || {},
-      analysis: (data.analysis && (data.analysis.text || data.analysis)) || data.economic_analysis || {},
-      insights: (data.insights && (data.insights.text || data.insights)) || {},
-      summary_text: data.summary_text || ''
+      summary_text: data.summary_text || '',
+      analysis_text: data.analysis_text || '',
+      insights_text: data.insights_text || ''
     });
     setStatus && setStatus('Done');
   } else {
@@ -47,15 +46,13 @@ async function generateFromSingleFile() {
 function renderSummaryAnalysisInsightsOnly(payload) {
   const box = document.getElementById('result_box');
   box.innerHTML = '';
-  const { summary_text, analysis = {}, insights = {} } = payload || {};
+  const { summary_text = '', analysis_text = '', insights_text = '' } = payload || {};
 
   // Render EXACTLY three text blocks (nothing else)
-  const analysisText = typeof analysis === 'string' ? analysis : (analysis && analysis.text) || '';
-  const insightsText = typeof insights === 'string' ? insights : (insights && insights.text) || '';
   const blocks = []
     .concat(summary_text ? ["Summary", summary_text] : [])
-    .concat(analysisText ? ["Financial analysis", analysisText] : [])
-    .concat(insightsText ? ["Financial insights", insightsText] : []);
+    .concat(analysis_text ? ["Financial analysis", analysis_text] : [])
+    .concat(insights_text ? ["Financial insights", insights_text] : []);
   box.textContent = blocks.join("\n\n");
 }
 

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -608,15 +608,13 @@
     }
     const textOnly = (
       data.kind === 'insights' || data.mode === 'insights' ||
-      data.summary_text ||
-      (data.analysis && (data.analysis.text || data.analysis)) ||
-      (data.insights && (data.insights.text || data.insights))
+      data.summary_text || data.analysis_text || data.insights_text
     );
     if (textOnly) {
       renderSummaryAnalysisInsightsOnly({
         summary_text: data.summary_text || '',
-        analysis: (data.analysis && (data.analysis.text || data.analysis)) || data.economic_analysis || '',
-        insights: (data.insights && (data.insights.text || data.insights)) || ''
+        analysis_text: data.analysis_text || '',
+        insights_text: data.insights_text || ''
       });
       return;
     }
@@ -692,13 +690,11 @@
   function renderSummaryAnalysisInsightsOnly(payload) {
     const box = $('result');
     box.innerHTML = '';
-    const { summary_text, analysis = {}, insights = {} } = payload || {};
-    const analysisText = typeof analysis === 'string' ? analysis : (analysis && analysis.text) || '';
-    const insightsText = typeof insights === 'string' ? insights : (insights && insights.text) || '';
+    const { summary_text = '', analysis_text = '', insights_text = '' } = payload || {};
     const sections = []
       .concat(summary_text ? `<h3>Summary</h3><p>${escapeHtml(summary_text)}</p>` : [])
-      .concat(analysisText ? `<h3>Financial analysis</h3><p>${escapeHtml(analysisText)}</p>` : [])
-      .concat(insightsText ? `<h3>Financial insights</h3><p>${escapeHtml(insightsText)}</p>` : []);
+      .concat(analysis_text ? `<h3>Financial analysis</h3><p>${escapeHtml(analysis_text)}</p>` : [])
+      .concat(insights_text ? `<h3>Financial insights</h3><p>${escapeHtml(insights_text)}</p>` : []);
     const wrap = document.createElement('section');
     wrap.className = 'report__card';
     wrap.innerHTML = sections.join('');

--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -8,6 +8,7 @@ def test_analyze_single_file_discards_cards():
     pdf_path = pathlib.Path('samples/procurement_example.pdf')
     data = pdf_path.read_bytes()
     res = asyncio.run(analyze_single_file(data, pdf_path.name))
-    assert "summary" in res and "analysis" in res and "insights" in res
     assert isinstance(res.get("summary_text"), str)
-    assert "items" not in res.get("summary", {})
+    assert isinstance(res.get("analysis_text"), str)
+    assert isinstance(res.get("insights_text"), str)
+    assert "summary" not in res and "analysis" not in res and "insights" not in res

--- a/tests/test_doors_quotes_adapter.py
+++ b/tests/test_doors_quotes_adapter.py
@@ -34,5 +34,6 @@ def test_doors_quotes_adapter_handles_workbook():
     data = _build_workbook()
     resp = process_single_file('doors_quotes.xlsx', data)
     assert 'summary_text' in resp
-    assert 'analysis' in resp and isinstance(resp['analysis'], dict)
-    assert 'insights' in resp and isinstance(resp['insights'], dict)
+    assert 'analysis_text' in resp and isinstance(resp['analysis_text'], str)
+    assert 'insights_text' in resp and isinstance(resp['insights_text'], str)
+    assert 'analysis' not in resp and 'insights' not in resp

--- a/tests/test_drafts_from_file_multisheet.py
+++ b/tests/test_drafts_from_file_multisheet.py
@@ -37,5 +37,6 @@ def test_drafts_from_file_returns_insights():
     data = resp.json()
     assert data["kind"] == "insights"
     assert "summary_text" in data
-    assert "analysis" in data and isinstance(data["analysis"], dict)
-    assert "insights" in data and isinstance(data["insights"], dict)
+    assert "analysis_text" in data and isinstance(data["analysis_text"], str)
+    assert "insights_text" in data and isinstance(data["insights_text"], str)
+    assert "analysis" not in data and "insights" not in data

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -11,5 +11,6 @@ def test_from_file_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary_text" in j
-    assert "analysis" in j and isinstance(j["analysis"], dict)
-    assert "insights" in j and isinstance(j["insights"], dict)
+    assert "analysis_text" in j and isinstance(j["analysis_text"], str)
+    assert "insights_text" in j and isinstance(j["insights_text"], str)
+    assert "analysis" not in j and "insights" not in j

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -13,5 +13,6 @@ def test_pdf_no_variance():
     j = r.json()
     assert j["kind"] == "insights"
     assert "summary_text" in j
-    assert "analysis" in j and isinstance(j["analysis"], dict)
-    assert "insights" in j and isinstance(j["insights"], dict)
+    assert "analysis_text" in j and isinstance(j["analysis_text"], str)
+    assert "insights_text" in j and isinstance(j["insights_text"], str)
+    assert "analysis" not in j and "insights" not in j

--- a/tests/test_single_generate_procurement.py
+++ b/tests/test_single_generate_procurement.py
@@ -13,5 +13,6 @@ def test_single_generate_returns_summary_analysis_insights():
     assert resp.status_code == 200
     data = resp.json()
     assert "summary_text" in data
-    assert "analysis" in data and isinstance(data["analysis"], dict)
-    assert "insights" in data and isinstance(data["insights"], dict)
+    assert "analysis_text" in data and isinstance(data["analysis_text"], str)
+    assert "insights_text" in data and isinstance(data["insights_text"], str)
+    assert "analysis" not in data and "insights" not in data

--- a/tests/test_singlefile_doors_quotes_like.py
+++ b/tests/test_singlefile_doors_quotes_like.py
@@ -23,6 +23,7 @@ def test_doors_quotes_like_excel_returns_summary():
     b = _xlsx_bytes(df)
     resp = process_single_file("doors_quotes_complete.xlsx", b)
     assert "summary_text" in resp
-    assert "analysis" in resp and isinstance(resp["analysis"], dict)
-    assert "insights" in resp and isinstance(resp["insights"], dict)
+    assert "analysis_text" in resp and isinstance(resp["analysis_text"], str)
+    assert "insights_text" in resp and isinstance(resp["insights_text"], str)
+    assert "analysis" not in resp and "insights" not in resp
 

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -7,7 +7,8 @@ def test_pdf_produces_summary_and_insights():
     data = Path('samples/procurement_example.pdf').read_bytes()
     res = process_single_file('procurement_example.pdf', data)
     assert 'summary_text' in res and isinstance(res['summary_text'], str)
-    assert isinstance(res.get('analysis'), dict)
-    assert isinstance(res.get('insights'), dict)
+    assert 'analysis_text' in res and isinstance(res['analysis_text'], str)
+    assert 'insights_text' in res and isinstance(res['insights_text'], str)
+    assert 'analysis' not in res and 'insights' not in res
     assert 'items' not in res
     assert 'mode' not in res


### PR DESCRIPTION
## Summary
- Ensure single-file uploads are always processed by ChatGPT
- Simplify single-file output to three plain-text fields: summary_text, analysis_text, and insights_text
- Update UI and tests to render exactly three sections: Summary, Financial analysis, Financial insights

## Testing
- `ruff check app/services/singlefile.py app/parsers/single_file.py tests/test_analyze_single_file_no_cards.py tests/test_singlefile_pdf.py tests/test_doors_quotes_adapter.py tests/test_singlefile_doors_quotes_like.py tests/test_from_file_no_variance_returns_summary_and_insights.py tests/test_drafts_from_file_multisheet.py tests/test_pdf_no_variance_returns_summary_and_insights.py tests/test_single_generate_procurement.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb85908d6c832a9520b391ddd5acd4