### PR TITLE
Provide fallback summaries for single-file uploads

### DIFF
--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -9,6 +9,9 @@ def test_analyze_single_file_discards_cards():
     data = pdf_path.read_bytes()
     res = asyncio.run(analyze_single_file(data, pdf_path.name))
     assert isinstance(res.get("summary_text"), str)
+    assert res.get("summary_text").strip()
     assert isinstance(res.get("analysis_text"), str)
+    assert res.get("analysis_text").strip()
     assert isinstance(res.get("insights_text"), str)
+    assert res.get("insights_text").strip()
     assert "summary" not in res and "analysis" not in res and "insights" not in res

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -10,7 +10,9 @@ def test_from_file_no_variance():
     assert r.status_code == 200
     j = r.json()
     assert j["kind"] == "insights"
-    assert "summary_text" in j
+    assert "summary_text" in j and j["summary_text"].strip()
     assert "analysis_text" in j and isinstance(j["analysis_text"], str)
+    assert j["analysis_text"].strip()
     assert "insights_text" in j and isinstance(j["insights_text"], str)
+    assert j["insights_text"].strip()
     assert "analysis" not in j and "insights" not in j

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -12,7 +12,9 @@ def test_pdf_no_variance():
     assert r.status_code == 200
     j = r.json()
     assert j["kind"] == "insights"
-    assert "summary_text" in j
+    assert "summary_text" in j and j["summary_text"].strip()
     assert "analysis_text" in j and isinstance(j["analysis_text"], str)
+    assert j["analysis_text"].strip()
     assert "insights_text" in j and isinstance(j["insights_text"], str)
+    assert j["insights_text"].strip()
     assert "analysis" not in j and "insights" not in j

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -9,6 +9,9 @@ def test_pdf_produces_summary_and_insights():
     assert 'summary_text' in res and isinstance(res['summary_text'], str)
     assert 'analysis_text' in res and isinstance(res['analysis_text'], str)
     assert 'insights_text' in res and isinstance(res['insights_text'], str)
+    assert res['summary_text'].strip()
+    assert res['analysis_text'].strip()
+    assert res['insights_text'].strip()
     assert 'analysis' not in res and 'insights' not in res
     assert 'items' not in res
     assert 'mode' not in res


### PR DESCRIPTION
## Summary
- add heuristic fallback in `llm_financial_summary` to return summary, analysis, and insights when OpenAI is unavailable
- extend single-file tests to require non-empty summary, financial analysis, and financial insights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbffa3a170832ab77914b4f36404a4