### PR TITLE
Offload single-file analysis to background thread

### DIFF
--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+import asyncio
 
 from app.services.singlefile import process_single_file
 
@@ -9,6 +10,13 @@ async def analyze_single_file(
     bilingual: bool = True,
     no_speculation: bool = True,
 ) -> Dict[str, Any]:
-    """Analyze a single file by delegating to ChatGPT for insights."""
-    res = process_single_file(name, data)
+    """Analyze a single file by delegating to ChatGPT for insights.
+
+    ``process_single_file`` performs synchronous, potentially heavy operations such
+    as PDF or spreadsheet parsing.  When called from an async FastAPI endpoint this
+    would block the event loop, preventing other requests from being served.  To
+    keep the single-file track responsive we offload the processing to a worker
+    thread via :func:`asyncio.to_thread`.
+    """
+    res = await asyncio.to_thread(process_single_file, name, data)
     return {"report_type": "summary", **res, "source": name}


### PR DESCRIPTION
## Summary
- prevent the async `analyze_single_file` helper from blocking the event loop
- explain why the processing is dispatched to a worker thread

## Testing
- `pytest tests/test_analyze_single_file_no_cards.py::test_analyze_single_file_discards_cards -q`
- `pytest tests/test_singlefile_pdf.py::test_pdf_produces_summary_and_insights -q`
- `pytest tests/test_singlefile_doors_quotes_like.py::test_doors_quotes_like_excel_returns_summary -q`
- `pytest tests/test_single_generate_procurement.py::test_single_generate_returns_summary_analysis_insights -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0506b4f8832abba1bc0975ab45e2