### PR TITLE
Offload single-file uploads to worker threads

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,3 +1,4 @@
+import asyncio
 from fastapi import UploadFile, File, Form
 
 from app.main import app
@@ -8,7 +9,7 @@ from app.services.singlefile import process_single_file
 @app.post("/single/generate")
 async def single_generate(file: UploadFile = File(...), bilingual: bool = Form(True)):
     """Return LLM-generated summary/analysis/insights for any single file upload."""
-    b = await file.read()
-    res = process_single_file(file.filename, b)
+    data = await file.read()
+    res = await asyncio.to_thread(process_single_file, file.filename or "upload.bin", data)
     return {"kind": "insights", **res}
 

--- a/app/main.py
+++ b/app/main.py
@@ -1048,7 +1048,7 @@ async def drafts_upload(
 async def singlefile_report(file: UploadFile = File(...)) -> Dict[str, Any]:
     """Return summary/analysis/insights for a single uploaded file."""
     data = await file.read()
-    res = process_single_file(file.filename or "upload.bin", data)
+    res = await asyncio.to_thread(process_single_file, file.filename or "upload.bin", data)
     return {"kind": "insights", **res}
 
 


### PR DESCRIPTION
## Summary
- Avoid blocking the event loop when handling single-file uploads
- Use `asyncio.to_thread` to process files before sending to the LLM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0881ab38832a8afde6b2ebc2bf9f