### PR TITLE
feat: add drafts envelope response

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -73,8 +73,13 @@ class SummaryResponse(BaseModel):
     message: str
     insights: Dict[str, Any] = Field(default_factory=dict)
 
+# Envelope used by /drafts to return the list together with metadata
+class DraftsEnvelope(BaseModel):
+    variances: List[DraftResponse]
+    _meta: Optional[Dict[str, Any]] = None
 
-DraftsOrSummary = Union[List[DraftResponse], SummaryResponse]
+# Endpoints may return either the wrapped list of drafts or a summary
+DraftsOrSummary = Union[DraftsEnvelope, SummaryResponse]
 
 
 class TokenUsage(BaseModel):


### PR DESCRIPTION
## Summary
- wrap draft responses in a `DraftsEnvelope` including variances and optional metadata
- allow endpoints to return the envelope or a summary via updated `DraftsOrSummary`

## Testing
- `pytest -q` *(fails: AttributeError, assertion errors in API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58732150832a886cbea192c6fcd3