### PR TITLE
Deploy workflow triggers only on meaningful changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,98 @@
+name: deploy
+on:
+  push:
+    branches: [ main ]
+    # Only trigger when meaningful files change
+    paths:
+      - 'src/**'
+      - 'backend/**'
+      - 'server/**'
+      - 'app/**'
+      - 'azure/**'
+      - 'infra/**'
+      - 'Dockerfile'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch: {}   # allow manual runs
+
+concurrency:
+  group: oaktree-dev-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      force: ${{ steps.force.outputs.force }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'backend/**'
+              - 'server/**'
+              - 'app/**'
+              - 'azure/**'
+              - 'infra/**'
+              - 'Dockerfile'
+              - 'requirements*.txt'
+              - 'pyproject.toml'
+              - 'poetry.lock'
+              - '.github/workflows/deploy.yml'
+      - id: force
+        run: |
+          msg="${{ github.event.head_commit.message }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "$msg" == *"[deploy]"* ]] || [[ "${{ startsWith(github.ref, 'refs/tags/deploy-') }}" == "true" ]]; then
+            echo "force=true" >> $GITHUB_OUTPUT
+          else
+            echo "force=false" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.force == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - name: Package artifact
+        run: |
+          mkdir -p package && cp -R * package/
+          echo "Zipping…" && cd package && zip -qry ../app.zip .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: app.zip
+
+  deploy:
+    needs: build
+    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.force == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: app, path: . }
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Ensure Azure doesn't rebuild (one-time, idempotent)
+        run: |
+          az webapp config appsettings set \
+            --name oaktree-variance-dev \
+            --resource-group <YOUR_RG> \
+            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false
+      - name: Deploy zip
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: oaktree-variance-dev
+          package: app.zip


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build & deploy only when app code or infra changes
- allow forcing deploy via commit message, tag, or manual dispatch
- package code, upload artifact, and deploy zipped app to Azure

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 7 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ad5a37c832aa55d285f41cbe4bb