### PR TITLE
ci: package deploy artifact without CI files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,11 @@ jobs:
       - run: pip install -r requirements.txt
       - name: Package artifact
         run: |
-          mkdir -p package && cp -R * package/
-          echo "Zipping…" && cd package && zip -qry ../app.zip .
+          # Create a clean zip of the repo contents (tracked + untracked),
+          # excluding CI files and junk; no self-recursive copy.
+          zip -qry app.zip . \
+            -x "./.git/*" "./.github/*" "./app.zip" "**/__pycache__/*" "*.pyc" ".venv/*" "venv/*" "node_modules/*"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- zip repo contents for deploy without copying folder or including CI files

## Testing
- `pytest` *(fails: 7 failed, 23 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68bc5e37286c832a80b6bb236cf358f1