### PR TITLE
refactor: migrate to OpenAI responses API

### DIFF
--- a/app/llm/extract_from_text.py
+++ b/app/llm/extract_from_text.py
@@ -6,10 +6,9 @@ Only used as a fallback when deterministic parsing is incomplete.
 from typing import List, Dict, Any
 import os
 import json
-from openai import OpenAI
+from openai_client_helper import build_client
 
-_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=_api_key) if _api_key else None
+client = build_client() if os.getenv("OPENAI_API_KEY") else None
 
 SYSTEM = (
   "You extract JSON ONLY from the provided text. "

--- a/openai_client_helper.py
+++ b/openai_client_helper.py
@@ -1,0 +1,14 @@
+import os
+from openai import OpenAI
+
+def build_client():
+    base = os.getenv("OPENAI_BASE_URL") or None
+    api_key = os.getenv("OPENAI_API_KEY") or None
+    timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
+    retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+    params = {"timeout": timeout, "max_retries": retries}
+    if base:
+        params["base_url"] = base
+    if api_key:
+        params["api_key"] = api_key
+    return OpenAI(**params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.116.1
 uvicorn==0.35.0
 pydantic==2.11.7
-openai==1.102.0
+openai>=1.0.0,<2.0.0
 pandas>=2.1.0
 pdfplumber==0.11.4
 pypdf==4.2.0

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -5,24 +5,22 @@ from app.schemas import VarianceItem, ConfigModel
 class DummyOpenAI:
     last_kwargs = None
 
-    def __init__(self, api_key: str, timeout: int, max_retries: int):
+    def __init__(self, api_key=None, timeout=None, max_retries=None, base_url=None):
         DummyOpenAI.last_kwargs = {
             "api_key": api_key,
             "timeout": timeout,
             "max_retries": max_retries,
         }
-        class _Chat:
-            class _Completions:
-                def create(self, *args, **kwargs):
-                    raise TimeoutError("boom")
-            completions = _Completions()
-        self.chat = _Chat()
+        class _Responses:
+            def create(self, *args, **kwargs):
+                raise TimeoutError("boom")
+        self.responses = _Responses()
 
 def test_generate_draft_timeout(monkeypatch):
     os.environ["OPENAI_API_KEY"] = "sk-test"
     os.environ["OPENAI_TIMEOUT"] = "1"
     os.environ["OPENAI_MAX_RETRIES"] = "5"
-    monkeypatch.setattr("openai.OpenAI", DummyOpenAI)
+    monkeypatch.setattr("openai_client_helper.OpenAI", DummyOpenAI)
 
     v = VarianceItem(
         project_id="P1",


### PR DESCRIPTION
## Summary
- add helper to construct OpenAI client from env vars
- switch GPT utilities to Responses API and helper
- update diagnostics endpoint for OpenAI client

## Testing
- `ruff check app/main.py app/gpt_client.py app/services/llm.py app/llm/extract_from_text.py tests/test_gpt_client.py`
- `pytest` *(fails: AttributeError in analyze_single_file_no_cards, assertion failures in API and upload tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8968f764832a95ddbff2a6c9c230