### PR TITLE
refactor: migrate to OpenAI responses API

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,7 +5,6 @@ from fastapi import UploadFile, File, Form, Request
 from app.main import app
 from app.services.singlefile import process_single_file
 from app.utils.local import is_local_only
-from app.schemas import GenerationMeta
 
 
 logger = logging.getLogger(__name__)
@@ -17,9 +16,15 @@ async def single_generate(request: Request, file: UploadFile = File(...), biling
     """Return LLM-generated summary/analysis/insights for any single file upload."""
     data = await file.read()
     local_only = is_local_only(request)
-    res, meta = await asyncio.to_thread(
+    res = await asyncio.to_thread(
         process_single_file, file.filename or "upload.bin", data, local_only=local_only
     )
-    logger.info("single_generate llm_used=%s model=%s forced_local=%s", meta.llm_used, meta.model, meta.forced_local)
-    return {"kind": "insights", **res, "_meta": meta.model_dump()}
+    meta = res.get("_meta", {})
+    logger.info(
+        "single_generate llm_used=%s model=%s forced_local=%s",
+        meta.get("llm_used"),
+        meta.get("model"),
+        meta.get("forced_local"),
+    )
+    return {"kind": "insights", **res}
 

--- a/app/llm/extract_from_text.py
+++ b/app/llm/extract_from_text.py
@@ -6,10 +6,9 @@ Only used as a fallback when deterministic parsing is incomplete.
 from typing import List, Dict, Any
 import os
 import json
-from openai import OpenAI
+from openai_client_helper import build_client
 
-_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=_api_key) if _api_key else None
+client = build_client() if os.getenv("OPENAI_API_KEY") else None
 
 SYSTEM = (
   "You extract JSON ONLY from the provided text. "

--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -1,8 +1,7 @@
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
 import asyncio
 
 from app.services.singlefile import process_single_file
-from app.schemas import GenerationMeta
 
 
 async def analyze_single_file(
@@ -12,13 +11,15 @@ async def analyze_single_file(
     no_speculation: bool = True,
     *,
     local_only: bool = False,
-) -> Tuple[Dict[str, Any], GenerationMeta]:
+) -> Dict[str, Any]:
     """Analyze a single file by delegating to ChatGPT for insights.
 
-    ``process_single_file`` sends the raw file to the OpenAI API.  The network
+    ``process_single_file`` sends the raw file to the OpenAI API. The network
     call is synchronous, so when invoked from an async FastAPI endpoint we
     offload the work to a thread via :func:`asyncio.to_thread` to avoid blocking
-    the event loop.
+    the event loop.  ``GenerationMeta`` is already embedded in the returned
+    dictionary via ``"_meta"``.
     """
-    res, meta = await asyncio.to_thread(process_single_file, name, data, local_only=local_only)
-    return {"report_type": "summary", **res, "source": name}, meta
+    res = await asyncio.to_thread(process_single_file, name, data, local_only=local_only)
+    res.update({"report_type": "summary", "source": name})
+    return res

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -21,10 +21,16 @@ async def from_file(request: Request, file: UploadFile = File(...)):
     try:
         data = await file.read()
         local_only = is_local_only(request)
-        res, meta = await asyncio.to_thread(
+        res = await asyncio.to_thread(
             process_single_file, file.filename, data, local_only=local_only
         )
-        logger.info("drafts/from-file llm_used=%s model=%s forced_local=%s", meta.llm_used, meta.model, meta.forced_local)
-        return {"kind": "insights", **res, "_meta": meta.model_dump()}
+        meta = res.get("_meta", {})
+        logger.info(
+            "drafts/from-file llm_used=%s model=%s forced_local=%s",
+            meta.get("llm_used"),
+            meta.get("model"),
+            meta.get("forced_local"),
+        )
+        return {"kind": "insights", **res}
     except Exception as e:  # pragma: no cover - defensive
         return {"error": str(e)}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 
 """Pydantic data models for the Variance Drafts service."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import List, Optional, Any, Dict, Union
 from typing_extensions import Literal
 
@@ -76,7 +76,8 @@ class SummaryResponse(BaseModel):
 # Envelope used by /drafts to return the list together with metadata
 class DraftsEnvelope(BaseModel):
     variances: List[DraftResponse]
-    _meta: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = Field(default=None, alias="_meta")
+    model_config = ConfigDict(protected_namespaces=())
 
 # Endpoints may return either the wrapped list of drafts or a summary
 DraftsOrSummary = Union[DraftsEnvelope, SummaryResponse]

--- a/openai_client_helper.py
+++ b/openai_client_helper.py
@@ -1,0 +1,14 @@
+import os
+from openai import OpenAI
+
+def build_client():
+    base = os.getenv("OPENAI_BASE_URL") or None
+    api_key = os.getenv("OPENAI_API_KEY") or None
+    timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
+    retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+    params = {"timeout": timeout, "max_retries": retries}
+    if base:
+        params["base_url"] = base
+    if api_key:
+        params["api_key"] = api_key
+    return OpenAI(**params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.116.1
 uvicorn==0.35.0
 pydantic==2.11.7
-openai==1.102.0
+openai>=1.0.0,<2.0.0
 pandas>=2.1.0
 pdfplumber==0.11.4
 pypdf==4.2.0

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -5,24 +5,22 @@ from app.schemas import VarianceItem, ConfigModel
 class DummyOpenAI:
     last_kwargs = None
 
-    def __init__(self, api_key: str, timeout: int, max_retries: int):
+    def __init__(self, api_key=None, timeout=None, max_retries=None, base_url=None):
         DummyOpenAI.last_kwargs = {
             "api_key": api_key,
             "timeout": timeout,
             "max_retries": max_retries,
         }
-        class _Chat:
-            class _Completions:
-                def create(self, *args, **kwargs):
-                    raise TimeoutError("boom")
-            completions = _Completions()
-        self.chat = _Chat()
+        class _Responses:
+            def create(self, *args, **kwargs):
+                raise TimeoutError("boom")
+        self.responses = _Responses()
 
 def test_generate_draft_timeout(monkeypatch):
     os.environ["OPENAI_API_KEY"] = "sk-test"
     os.environ["OPENAI_TIMEOUT"] = "1"
     os.environ["OPENAI_MAX_RETRIES"] = "5"
-    monkeypatch.setattr("openai.OpenAI", DummyOpenAI)
+    monkeypatch.setattr("openai_client_helper.OpenAI", DummyOpenAI)
 
     v = VarianceItem(
         project_id="P1",


### PR DESCRIPTION
## Summary
- embed generation metadata directly in single-file analysis results
- restore legacy list response for structured uploads and handle LLM extraction failures gracefully
- expose `_meta` in drafts envelopes through a Pydantic alias

## Testing
- `ruff check app/services/singlefile.py app/parsers/single_file.py app/api.py app/routers/drafts.py app/main.py app/schemas.py tests/test_doors_quotes_adapter.py tests/test_singlefile_pdf.py tests/test_singlefile_doors_quotes_like.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8968f764832a95ddbff2a6c9c230