### PR TITLE
CI: fix Oryx deploy (only require requirements.txt; auto-set FastAPI startup)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,11 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
     env:
-      RG: oaktree-variance-dev-rg
-      APP: oaktree-variance-dev
-      API_PATH: .
+      RG: ${RG}
+      APP: ${APP}
+      API_PATH: ${API_PATH}
 
     steps:
       - name: Checkout
@@ -20,17 +21,34 @@ jobs:
 
       - name: Show backend contents
         run: |
-          echo "Backend path: $API_PATH"
-          ls -la "$API_PATH"
+          echo "Backend path: \$API_PATH"
+          ls -la "\$API_PATH"
 
+      # Only require requirements.txt so Oryx detects Python.
       - name: Validate backend layout
         run: |
-          test -f "$API_PATH/requirements.txt" || { echo "requirements.txt not found under $API_PATH"; exit 1; }
-          test -f "$API_PATH/app.py" -o -f "$API_PATH/main.py" || { echo "app.py/main.py not found under $API_PATH"; exit 1; }
+          test -f "\$API_PATH/requirements.txt" || { echo "requirements.txt not found under \$API_PATH"; exit 1; }
+
+      # Try to auto-detect a FastAPI module and prepare a startup command.
+      - name: Detect FastAPI app and set startup command
+        id: startup
+        run: |
+          set -e
+          MOD_FILE="$(grep -RIl --include='*.py' 'FastAPI(' "\$API_PATH" | head -n1 || true)"
+          if [ -n "\$MOD_FILE" ]; then
+            MOD_NOEXT="${MOD_FILE%.py}"
+            MOD_REL="${MOD_NOEXT#${API_PATH}/}"
+            MOD="${MOD_REL//\//.}"
+            CMD="gunicorn -k uvicorn.workers.UvicornWorker ${MOD}:app"
+            echo "Detected module: ${MOD}"
+            echo "STARTUP_CMD=${CMD}" >> "\$GITHUB_ENV"
+          else
+            echo "No FastAPI module auto-detected; leaving startup unchanged."
+          fi
 
       - name: Build deployable artifact (zip root = backend)
         run: |
-          cd "$API_PATH"
+          cd "\$API_PATH"
           zip -r ../app.zip .
           cd -
           unzip -l app.zip | head -n 20
@@ -45,11 +63,17 @@ jobs:
       - name: Deploy zip to Azure Web App
         run: |
           az webapp deploy \
-            --resource-group "$RG" \
-            --name "$APP" \
+            --resource-group "\$RG" \
+            --name "\$APP" \
             --type zip \
             --src-path app.zip \
             --clean true
 
+      - name: Apply startup command if detected
+        if: env.STARTUP_CMD != ''
+        run: |
+          echo "Setting startup command: \$STARTUP_CMD"
+          az webapp config set -g "\$RG" -n "\$APP" --startup-file "\$STARTUP_CMD"
+
       - name: Show site URL
-        run: az webapp show -g "$RG" -n "$APP" --query defaultHostName -o tsv
+        run: az webapp show -g "\$RG" -n "\$APP" --query defaultHostName -o tsv


### PR DESCRIPTION
## Summary
- simplify Azure deployment workflow to only require `requirements.txt` for Oryx
- auto-detect FastAPI module and configure startup command

## Testing
- `pytest` *(fails: tests/test_analyze_single_file_no_cards.py::test_analyze_single_file_discards_cards - AttributeError: 'tuple' object h..., tests/test_api.py::test_create_drafts_endpoint - AssertionError: assert '_meta' in {'variances': [{'analyst_notes': No..., tests/test_doors_quotes_adapter.py::test_doors_quotes_adapter_handles_workbook - AssertionError: assert 'summary_text'..., tests/test_singlefile_doors_quotes_like.py::test_doors_quotes_like_excel_returns_summary - AssertionError: assert 'sum..., tests/test_singlefile_pdf.py::test_pdf_produces_summary_and_insights - AssertionError: assert ('summary_text' in ({'an..., tests/test_upload.py::test_upload_endpoint - AssertionError: assert False, tests/test_upload.py::test_upload_endpoint_excel - AssertionError: assert False, tests/test_upload.py::test_upload_llm_failure - assert 502 == 200)`

------
https://chatgpt.com/codex/tasks/task_e_68bc94d8465c832a83c22f90329067ed