### PR TITLE
Handle repo root in deploy artifact step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,12 @@ jobs:
           cd "$APP_DIR"
           pipx install build >/dev/null 2>&1 || true
           # Create a clean zip, excluding junk
-          zip -qry ../app.zip . \
+          if [ "$APP_DIR" = "." ]; then
+            ZIP_PATH="app.zip"
+          else
+            ZIP_PATH="../app.zip"
+          fi
+          zip -qry "$ZIP_PATH" . \
             -x "./.git/*" "./.github/*" "./app.zip" "**/__pycache__/*" "*.pyc" ".venv/*" "venv/*" "node_modules/*"
           cd -
           ls -lh app.zip


### PR DESCRIPTION
## Summary
- handle app dir == repo root when zipping deploy artifact

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: AttributeError and assertion errors in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc982c9f10832aacf5481b29e0753d