### PR TITLE
chore: parameterize Azure webapp deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      AZURE_WEBAPP_NAME: oaktree-variance-dev
+      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
 
     steps:
       - name: Checkout
@@ -79,11 +82,11 @@ jobs:
         shell: bash
         run: |
           az webapp deployment source delete \
-            --name oaktree-variance-dev \
-            --resource-group <YOUR_RESOURCE_GROUP> || true
+            --name "$AZURE_WEBAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" || true
           az webapp config appsettings set \
-            --name oaktree-variance-dev \
-            --resource-group <YOUR_RESOURCE_GROUP> \
+            --name "$AZURE_WEBAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
             --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false
 
       # 6) Zip deploy with a safe retry (handles 409 lock)
@@ -92,7 +95,7 @@ jobs:
         uses: azure/webapps-deploy@v3
         continue-on-error: true
         with:
-          app-name: oaktree-variance-dev
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
           package: app.zip
 
       - name: Retry if first deploy failed
@@ -103,5 +106,5 @@ jobs:
         if: steps.deploy1.outcome == 'failure'
         uses: azure/webapps-deploy@v3
         with:
-          app-name: oaktree-variance-dev
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
           package: app.zip

--- a/.github/workflows/main_oaktree-variance-dev.yml
+++ b/.github/workflows/main_oaktree-variance-dev.yml
@@ -50,6 +50,9 @@ jobs:
     permissions:
       id-token: write #This is required for requesting the JWT
       contents: read #This is required for actions/checkout
+    env:
+      AZURE_WEBAPP_NAME: oaktree-variance-dev
+      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
 
     steps:
       - name: Download artifact from build job
@@ -69,7 +72,7 @@ jobs:
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
         with:
-          app-name: oaktree-variance-dev
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
           slot-name: 'Production'
           package: ${{ github.workspace }}/python-app
           startup-command: 'gunicorn -c gunicorn.conf.py app.main:app'


### PR DESCRIPTION
## Summary
- define AZURE_WEBAPP_NAME and AZURE_RESOURCE_GROUP as job-level env vars in deployment workflows
- use env vars in az CLI and Azure webapp deploy steps

## Testing
- `pytest` *(fails: test_analyze_single_file_no_cards.py::..., test_api.py::..., test_doors_quotes_adapter.py::..., test_singlefile_doors_quotes_like.py::..., test_singlefile_pdf.py::..., test_upload.py::test_upload_endpoint, test_upload.py::test_upload_endpoint_excel, test_upload.py::test_upload_llm_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bca2a988d4832abf334be591954bb0