### PR TITLE
Add Azure input validation to deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     env:
       AZURE_WEBAPP_NAME: oaktree-variance-dev
-      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+      AZURE_RESOURCE_GROUP: oaktree-variance-rg
 
     steps:
       - name: Checkout
@@ -76,6 +76,18 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Validate Azure inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          for v in AZURE_WEBAPP_NAME AZURE_RESOURCE_GROUP; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Missing $v"; exit 1
+            fi
+          done
+          echo "Using RG=$AZURE_RESOURCE_GROUP, APP=$AZURE_WEBAPP_NAME"
+          az group show -n "$AZURE_RESOURCE_GROUP" -o table
 
       # 5) Make sure Deployment Center is detached & Oryx rebuild is off (idempotent)
       - name: Prepare Web App for zip deploy

--- a/.github/workflows/main_oaktree-variance-dev.yml
+++ b/.github/workflows/main_oaktree-variance-dev.yml
@@ -52,7 +52,7 @@ jobs:
       contents: read #This is required for actions/checkout
     env:
       AZURE_WEBAPP_NAME: oaktree-variance-dev
-      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+      AZURE_RESOURCE_GROUP: oaktree-variance-rg
 
     steps:
       - name: Download artifact from build job
@@ -67,6 +67,18 @@ jobs:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_B5CCBBB1A0AD4D16B5FAB94C75816D05 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_6ABBBFAF71E44ACD95FCEFD7F302CC3C }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_46714C56CE4D4F9781F5CDD3F65A87D4 }}
+
+      - name: Validate Azure inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          for v in AZURE_WEBAPP_NAME AZURE_RESOURCE_GROUP; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Missing $v"; exit 1
+            fi
+          done
+          echo "Using RG=$AZURE_RESOURCE_GROUP, APP=$AZURE_WEBAPP_NAME"
+          az group show -n "$AZURE_RESOURCE_GROUP" -o table
 
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
## Summary
- set explicit Azure resource group and app name env vars for deployment jobs
- add Azure input validation step after login in deploy workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68bca6683598832a8e02c5b574ac3f97