### PR TITLE
Pin RG/app names and subscription for Azure deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     env:
       AZURE_WEBAPP_NAME: oaktree-variance-dev
-      AZURE_RESOURCE_GROUP: oaktree-variance-rg
+      AZURE_RESOURCE_GROUP: oaktree-variance-dev-rg
 
     steps:
       - name: Checkout

--- a/.github/workflows/main_oaktree-variance-dev.yml
+++ b/.github/workflows/main_oaktree-variance-dev.yml
@@ -52,7 +52,7 @@ jobs:
       contents: read #This is required for actions/checkout
     env:
       AZURE_WEBAPP_NAME: oaktree-variance-dev
-      AZURE_RESOURCE_GROUP: oaktree-variance-rg
+      AZURE_RESOURCE_GROUP: oaktree-variance-dev-rg
 
     steps:
       - name: Download artifact from build job
@@ -64,9 +64,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_B5CCBBB1A0AD4D16B5FAB94C75816D05 }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_6ABBBFAF71E44ACD95FCEFD7F302CC3C }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_46714C56CE4D4F9781F5CDD3F65A87D4 }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Who am I in Azure?
         shell: bash


### PR DESCRIPTION
## Summary
- align Azure deploy workflows to use `AZURE_WEBAPP_NAME` and `AZURE_RESOURCE_GROUP` for the dev environment
- authenticate with Azure using `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`

## Testing
- `pytest` *(fails: AttributeError and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb1edb7b8832a8fc6c3a33641e5ce