### PR TITLE
Fix APP_MODULE detection and defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           DETECT=""
           if [ -f main.py ] && grep -qi "FastAPI(" main.py; then
             DETECT="main:app"
+          elif [ -f app/main.py ] && grep -qi "FastAPI(" app/main.py; then
+            DETECT="app.main:app"
           elif [ -f app.py ] && grep -qi "Flask(" app.py; then
             DETECT="app:app"
           elif ls -1 **/wsgi.py >/dev/null 2>&1; then
@@ -130,7 +132,7 @@ jobs:
           CANDIDATES=()
           # include detected value (if any) and common fallbacks
           if [ -n "${APP_MODULE_DETECTED:-}" ]; then CANDIDATES+=("${APP_MODULE_DETECTED}"); fi
-          CANDIDATES+=("main:app" "app:app")
+          CANDIDATES+=("main:app" "app.main:app" "app:app")
 
           run_and_probe () {
             local module="$1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install -r requirements.txt && pip install gunicorn
 COPY . /app
 # App Service passes $PORT; expose a default dev port for local runs
 ENV PORT=8000
-# Configure your entrypoint via APP_MODULE (defaults to app:app). Example: "main:app" or "projectname.wsgi"
-ENV APP_MODULE=app:app
+# Configure your entrypoint via APP_MODULE (defaults to app.main:app). Example: "main:app" or "projectname.wsgi"
+ENV APP_MODULE=app.main:app
 # Start via gunicorn; override APP_MODULE in App Settings if your module is different
 CMD ["sh", "-c", "gunicorn -b 0.0.0.0:${PORT} ${APP_MODULE}"]


### PR DESCRIPTION
## Summary
- detect FastAPI app located at app/main.py during deployment
- update smoke-test to try app.main:app and adjust default APP_MODULE

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: test_analyze_single_file_discards_cards, test_create_drafts_endpoint, test_doors_quotes_adapter_handles_workbook, test_doors_quotes_like_excel_returns_summary, test_pdf_produces_summary_and_insights, test_upload_endpoint, test_upload_endpoint_excel, test_upload_llm_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd9af85ec832aaa459662742dc8d7