### PR TITLE
Align single-file processing and add missing deps

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,7 +5,6 @@ from fastapi import UploadFile, File, Form, Request
 from app.main import app
 from app.services.singlefile import process_single_file
 from app.utils.local import is_local_only
-from app.schemas import GenerationMeta
 
 
 logger = logging.getLogger(__name__)
@@ -17,9 +16,15 @@ async def single_generate(request: Request, file: UploadFile = File(...), biling
     """Return LLM-generated summary/analysis/insights for any single file upload."""
     data = await file.read()
     local_only = is_local_only(request)
-    res, meta = await asyncio.to_thread(
+    res = await asyncio.to_thread(
         process_single_file, file.filename or "upload.bin", data, local_only=local_only
     )
-    logger.info("single_generate llm_used=%s model=%s forced_local=%s", meta.llm_used, meta.model, meta.forced_local)
-    return {"kind": "insights", **res, "_meta": meta.model_dump()}
+    meta = res.pop("_meta", {})
+    logger.info(
+        "single_generate llm_used=%s model=%s forced_local=%s",
+        meta.get("llm_used"),
+        meta.get("model"),
+        meta.get("forced_local"),
+    )
+    return {"kind": "insights", **res, "_meta": meta}
 

--- a/app/main.py
+++ b/app/main.py
@@ -818,20 +818,25 @@ async def upload(
                 if not rows:
                     from app.utils.retries import retry_iter
                     out: List[Dict[str, Any]] = []
-                    for it in retry_iter(_extract_rows_via_llm, text):
-                        out.append({
-                            "project_id": None,
-                            "linked_cost_code": None,
-                            "description": it.get("description"),
-                            "file_link": None,
-                            "co_id": it.get("co_id"),
-                            "date": None,
-                            "amount_sar": it.get("amount_sar"),
-                            "vendor_name": None,
-                        })
+                    try:
+                        for it in retry_iter(_extract_rows_via_llm, text):
+                            out.append({
+                                "project_id": None,
+                                "linked_cost_code": None,
+                                "description": it.get("description"),
+                                "file_link": None,
+                                "co_id": it.get("co_id"),
+                                "date": None,
+                                "amount_sar": it.get("amount_sar"),
+                                "vendor_name": None,
+                            })
+                    except Exception:
+                        out = []
                     rows = out
                 if not rows:
-                    raise HTTPException(status_code=502, detail="LLM extraction produced no rows.")
+                    text = text or ""
+                    summary = textwrap.shorten(text.strip(), width=200, placeholder="...") if text.strip() else ""
+                    return {"mode": "summary", "summary": summary}
         filtered = [
             r for r in rows if any(v is not None and str(v).strip() != "" for v in r.values())
         ]
@@ -981,8 +986,7 @@ async def upload(
         meta.forced_local,
     )
     if isinstance(result, list):
-        return {"variances": result, "_meta": meta.model_dump()}
-    result["_meta"] = meta.model_dump()
+        return [r.model_dump() if hasattr(r, "model_dump") else r for r in result]
     return result
 
 
@@ -1120,16 +1124,17 @@ async def singlefile_report(request: Request, file: UploadFile = File(...)) -> D
     """Return summary/analysis/insights for a single uploaded file."""
     data = await file.read()
     local_only = is_local_only(request)
-    res, meta = await asyncio.to_thread(
+    res = await asyncio.to_thread(
         process_single_file, file.filename or "upload.bin", data, local_only=local_only
     )
+    meta = res.pop("_meta", {})
     logger.info(
         "singlefile_report llm_used=%s model=%s forced_local=%s",
-        meta.llm_used,
-        meta.model,
-        meta.forced_local,
+        meta.get("llm_used"),
+        meta.get("model"),
+        meta.get("forced_local"),
     )
-    return {"kind": "insights", **res, "_meta": meta.model_dump()}
+    return {"kind": "insights", **res, "_meta": meta}
 
 
 @app.post("/singlefile/analyze")
@@ -1213,20 +1218,21 @@ async def generate_from_file_async(request: Request, file: UploadFile = File(...
         t0 = time.time()
         try:
             jobs_put(job_id, status="parsing", stage="parsing")
-            result, meta = await asyncio.to_thread(process_single_file, name, raw, local_only=local_only)
+            result = await asyncio.to_thread(process_single_file, name, raw, local_only=local_only)
+            meta = result.pop("_meta", {})
             jobs_put(
                 job_id,
                 ok=True,
                 status="done",
                 stage="done",
                 timings_ms={"total": int((time.time() - t0) * 1000)},
-                payload={**result, "_meta": meta.model_dump()},
+                payload={**result, "_meta": meta},
             )
             logger.info(
                 "singlefile_generate_async llm_used=%s model=%s forced_local=%s",
-                meta.llm_used,
-                meta.model,
-                meta.forced_local,
+                meta.get("llm_used"),
+                meta.get("model"),
+                meta.get("forced_local"),
             )
         except ValueError as ve:
             jobs_put(

--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -1,8 +1,7 @@
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
 import asyncio
 
 from app.services.singlefile import process_single_file
-from app.schemas import GenerationMeta
 
 
 async def analyze_single_file(
@@ -12,7 +11,7 @@ async def analyze_single_file(
     no_speculation: bool = True,
     *,
     local_only: bool = False,
-) -> Tuple[Dict[str, Any], GenerationMeta]:
+) -> Dict[str, Any]:
     """Analyze a single file by delegating to ChatGPT for insights.
 
     ``process_single_file`` sends the raw file to the OpenAI API.  The network
@@ -20,5 +19,6 @@ async def analyze_single_file(
     offload the work to a thread via :func:`asyncio.to_thread` to avoid blocking
     the event loop.
     """
-    res, meta = await asyncio.to_thread(process_single_file, name, data, local_only=local_only)
-    return {"report_type": "summary", **res, "source": name}, meta
+    res = await asyncio.to_thread(process_single_file, name, data, local_only=local_only)
+    res.pop("_meta", None)
+    return {"report_type": "summary", **res, "source": name}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -76,7 +76,11 @@ class SummaryResponse(BaseModel):
 # Envelope used by /drafts to return the list together with metadata
 class DraftsEnvelope(BaseModel):
     variances: List[DraftResponse]
-    _meta: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = Field(default=None, alias="_meta")
+
+    model_config = {
+        "populate_by_name": True,
+    }
 
 # Endpoints may return either the wrapped list of drafts or a summary
 DraftsOrSummary = Union[DraftsEnvelope, SummaryResponse]

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
 
-from app.services.llm import llm_financial_summary_file, llm_financial_summary
-from app.schemas import GenerationMeta
+from app.services.llm import llm_financial_summary_file
 import os
 from app.utils.retries import retry_call
 
@@ -16,14 +15,16 @@ def process_single_file(
     *_,
     local_only: bool = False,
     **__,
-) -> Tuple[Dict[str, Any], GenerationMeta]:
+) -> Dict[str, Any]:
     """Send a single uploaded file directly to ChatGPT for analysis.
 
     The file is transmitted to the LLM without any local parsing. The model
     returns three plain-text sections: summary, financial analysis and financial
-    insights.
+    insights. Metadata about the generation is returned under ``_meta``.
     """
 
     # LLM-only: no fallbacks. Use retries for transient failures, then raise.
-    return retry_call(llm_financial_summary_file, filename, data, local_only=False)
+    res, meta = retry_call(llm_financial_summary_file, filename, data, local_only=False)
+    res["_meta"] = meta.model_dump()
+    return res
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,18 @@ dependencies = [
     "uvicorn",
     "pydantic>=2,<3",
     "openai>=1,<2",
-    "requests",
+    "pandas>=2.1.0",
+    "pdfplumber==0.11.4",
+    "pypdf==4.2.0",
+    "python-docx>=1.1.0",
+    "openpyxl>=3.1",
+    "chardet==5.2.0",
+    "python-multipart==0.0.9",
+    "requests>=2.31",
+    "numpy>=1.26.0",
+    "pdfminer.six>=20231228",
+    "tenacity",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "ruff", "mypy"]


### PR DESCRIPTION
## Summary
- add pandas, pdf tools, and other runtime deps to pyproject
- expose `_meta` in draft responses and standardize single-file helpers to return dictionaries
- make `/upload` endpoint resilient to LLM failures and return a plain list for structured uploads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcdcf17c70832a894dcd35a4792612