### PR TITLE
feat: support azure openai api key

### DIFF
--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -36,7 +36,12 @@ def generate_draft(v: VarianceItem, cfg: ConfigModel, *, local_only: bool = Fals
     available. Prompts forbid speculation so returned drafts remain
     grounded in the provided `VarianceItem` fields.
     """
-    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    # Support both OpenAI and Azure OpenAI environments
+    api_key = (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("AZURE_OPENAI_API_KEY")
+        or ""
+    ).strip()
     user_prompt = build_user_prompt(v, cfg)
     ar_instr = build_arabic_instruction() if cfg.bilingual else ""
 
@@ -89,7 +94,11 @@ def summarize_financials(summary: Dict[str, Any], analysis: Dict[str, Any]) -> s
         highlights.extend(analysis.get("highlights", []))
     fallback = " ".join(highlights).strip() or "No financial insights available."
 
-    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    api_key = (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("AZURE_OPENAI_API_KEY")
+        or ""
+    ).strip()
     if not api_key:
         return fallback
     try:

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -142,7 +142,12 @@ def llm_financial_summary_file(filename: str, data: bytes, *, local_only: bool =
     :func:`llm_financial_summary`.
     """
 
-    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    # Support both OpenAI and Azure OpenAI environments
+    api_key = (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("AZURE_OPENAI_API_KEY")
+        or ""
+    ).strip()
     if local_only or not api_key:
         from app.utils.file_to_text import file_bytes_to_text
 

--- a/openai_client_helper.py
+++ b/openai_client_helper.py
@@ -3,7 +3,8 @@ from openai import OpenAI
 
 def build_client():
     base = os.getenv("OPENAI_BASE_URL") or None
-    api_key = os.getenv("OPENAI_API_KEY") or None
+    # Accept either standard OpenAI or Azure OpenAI env var
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("AZURE_OPENAI_API_KEY") or None
     timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
     retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
     params = {"timeout": timeout, "max_retries": retries}


### PR DESCRIPTION
## Summary
- allow OpenAI client helper to read `AZURE_OPENAI_API_KEY`
- enable Azure OpenAI API key fallback in GPT client and LLM services

## Testing
- `ruff check openai_client_helper.py app/gpt_client.py app/services/llm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd77a8c988832ab19e6c5f24f11d5b