### PR TITLE
Ensure CA certificates installed in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 WORKDIR /app
+# --- Ensure TLS trust store is present so HTTPS to api.openai.com works ---
+# Put this BEFORE any `USER <non-root>` line and before your app starts.
+# Handles both Alpine and Debian/Ubuntu base images.
+RUN if [ -f /etc/alpine-release ]; then \
+      apk add --no-cache ca-certificates curl && update-ca-certificates ; \
+    else \
+      apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
+      rm -rf /var/lib/apt/lists/* && update-ca-certificates ; \
+    fi
 # Install system deps if you need them; keep minimal
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
 # Install Python deps


### PR DESCRIPTION
## Summary
- ensure TLS trust store is installed so HTTPS to api.openai.com works

## Testing
- `ruff check .` *(fails: Redefinition of unused `io` and others)*
- `mypy .` *(fails: library stubs for requests not installed; argument type errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd968e73c8832ab655724cd940b11c