### PR TITLE
Default single-file track to OpenAI with configurable local fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,35 @@ WEB_THREADS=8           # threads per worker
 WEB_TIMEOUT=240         # request timeout in seconds
 WEB_KEEPALIVE=5         # keepalive in seconds
 ```
+
+### LLM configuration
+```
+OPENAI_API_KEY or AZURE_OPENAI_API_KEY  # one required for OpenAI calls
+OPENAI_BASE_URL                         # optional custom endpoint
+OPENAI_MODEL=gpt-4o-mini                # default model
+FORCE_LLM=false                         # force OpenAI even if local_only=true
+LOCAL_FALLBACK_POLICY=on_error|never|if_no_key
+                                        # when to fall back locally
+```
+
+### Manual checks
+```
+# Happy path (OpenAI)
+curl -s -X POST http://localhost:8000/drafts/from-file \
+  -F file=@tests/fixtures/sample.pdf \
+  -F local_only=false | jq '._meta'
+
+# Body flag forces local
+curl -s -X POST http://localhost:8000/drafts/from-file \
+  -F file=@tests/fixtures/sample.pdf \
+  -F local_only=true | jq '._meta'
+
+# Header ignored
+curl -s -X POST http://localhost:8000/drafts/from-file \
+  -H "x-local-only: true" \
+  -F file=@tests/fixtures/sample.pdf | jq '._meta'
+
+# Fallback policy (prod style)
+LOCAL_FALLBACK_POLICY=never OPENAI_API_KEY= \
+  uvicorn app.main:app  # then call endpoint and expect clear error
+```

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,3 @@
+import os
+
+FORCE_LLM = os.getenv("FORCE_LLM", "").lower() in {"1", "true", "yes"}

--- a/app/llm/openai_client.py
+++ b/app/llm/openai_client.py
@@ -1,0 +1,36 @@
+import os
+from openai import OpenAI
+
+class OpenAIConfigError(RuntimeError):
+    pass
+
+def get_openai_model() -> str:
+    return os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+def get_openai_base_url():
+    return os.getenv("OPENAI_BASE_URL") or None
+
+def get_openai_key():
+    return os.getenv("OPENAI_API_KEY") or os.getenv("AZURE_OPENAI_API_KEY")
+
+def get_fallback_policy() -> str:
+    policy = os.getenv("LOCAL_FALLBACK_POLICY")
+    if not policy:
+        policy = "on_error" if os.getenv("ENV", "dev") != "prod" else "never"
+    return policy
+
+def ensure_openai_available():
+    key = get_openai_key()
+    if not key:
+        raise OpenAIConfigError("Missing OpenAI API key")
+    return key
+
+def build_client() -> OpenAI:
+    key = ensure_openai_available()
+    base = get_openai_base_url()
+    timeout = int(os.getenv("OPENAI_TIMEOUT", "30"))
+    retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+    params = {"api_key": key, "timeout": timeout, "max_retries": retries}
+    if base:
+        params["base_url"] = base
+    return OpenAI(**params)

--- a/tests/test_single_file_llm_routing.py
+++ b/tests/test_single_file_llm_routing.py
@@ -1,0 +1,145 @@
+from fastapi.testclient import TestClient
+import types
+import pytest
+
+from app.main import app, require_api_key
+from app.services.singlefile import process_single_file
+from app.llm.openai_client import OpenAIConfigError
+
+app.dependency_overrides[require_api_key] = lambda: None
+
+class DummyClient:
+    class files:
+        @staticmethod
+        def create(file, purpose, filename):
+            return types.SimpleNamespace(id="file123")
+
+    class responses:
+        @staticmethod
+        def create(model, input):
+            return types.SimpleNamespace(
+                output_text="Summary\n\nAnalysis\n\nInsights",
+                usage=types.SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+            )
+
+
+def test_single_file_local_only_true_uses_local(monkeypatch):
+    client = TestClient(app)
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    r = client.post("/drafts/from-file", files=files, data={"local_only": "true"})
+    assert r.status_code == 200
+    meta = r.json()["_meta"]
+    assert meta["llm_used"] == "local"
+    assert meta["provider"] == "local"
+    assert meta["forced_local"] is True
+
+
+def test_single_file_no_local_flag_uses_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
+    client = TestClient(app)
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    r = client.post("/drafts/from-file", files=files)
+    assert r.status_code == 200
+    meta = r.json()["_meta"]
+    assert meta["llm_used"] == "openai"
+    assert meta["provider"] == "openai"
+    assert meta["model"] == "gpt-4o-mini"
+    assert meta["forced_local"] is False
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_headers_ignored_for_local_only(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
+    client = TestClient(app)
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    r = client.post("/drafts/from-file", files=files, headers={"x-local-only": "true"})
+    assert r.status_code == 200
+    meta = r.json()["_meta"]
+    assert meta["llm_used"] == "openai"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_force_llm_overrides_local_flag(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr("app.services.singlefile.FORCE_LLM", True, raising=False)
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
+    client = TestClient(app)
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    r = client.post("/drafts/from-file", files=files, data={"local_only": "true"})
+    assert r.status_code == 200
+    meta = r.json()["_meta"]
+    assert meta["llm_used"] == "openai"
+    assert meta["forced_local"] is False
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_fallback_policy_on_error_missing_key(monkeypatch):
+    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "on_error")
+    res = process_single_file("note.txt", b"hi")
+    meta = res["_meta"]
+    assert meta["llm_used"] == "local"
+    assert meta["fallback_reason"] == "no_api_key"
+    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
+
+
+def test_fallback_policy_on_error_openai_exception(monkeypatch):
+    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "on_error")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    class BoomClient(DummyClient):
+        class responses:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: BoomClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: BoomClient())
+    res = process_single_file("note.txt", b"hi")
+    meta = res["_meta"]
+    assert meta["llm_used"] == "local"
+    assert meta["fallback_reason"].startswith("openai_error")
+    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_fallback_policy_never_missing_key(monkeypatch):
+    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "never")
+    try:
+        process_single_file("note.txt", b"hi")
+    except OpenAIConfigError:
+        pass
+    else:
+        assert False, "Expected OpenAIConfigError"
+    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
+
+
+def test_fallback_policy_if_no_key(monkeypatch):
+    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "if_no_key")
+    res = process_single_file("note.txt", b"hi")
+    meta = res["_meta"]
+    assert meta["llm_used"] == "local"
+    assert meta["fallback_reason"] == "no_api_key"
+    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
+
+
+def test_fallback_policy_if_no_key_openai_error(monkeypatch):
+    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "if_no_key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    class BoomClient(DummyClient):
+        class responses:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: BoomClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: BoomClient())
+    with pytest.raises(RuntimeError):
+        process_single_file("note.txt", b"hi")
+    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/workflows/single-file-chatgpt.yaml
+++ b/workflows/single-file-chatgpt.yaml
@@ -5,7 +5,6 @@ inputs:
     required: true
   local_only:
     type: boolean
-    required: false
     default: false   # ChatGPT by default; set true to force local
 
 actions:


### PR DESCRIPTION
## Summary
- Ignore headers/query for single-file uploads; only body flags can force local mode
- Add FORCE_LLM override and configurable OpenAI fallback policy with structured `_meta`
- Document OPENAI_* and LOCAL_FALLBACK_POLICY env vars and provide manual check commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf41f3b50832a89b6717d757fa97f