### PR TITLE
Disable local variance draft generation

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,36 +1,27 @@
-import asyncio
 import logging
-from fastapi import UploadFile, File, Form, Request
+import asyncio
+from fastapi import UploadFile, File, Form
 
 from app.main import app
 from app.services.singlefile import process_single_file
-from app.utils.local import is_local_only
-
 
 logger = logging.getLogger(__name__)
-
 
 # --- Single Data File endpoint ---
 @app.post("/single/generate")
 async def single_generate(
-    request: Request,
     file: UploadFile = File(...),
     bilingual: bool = Form(True),
-    local_only: bool = Form(False),
-    localOnly: bool = Form(False),
 ):
     """Return LLM-generated summary/analysis/insights for any single file upload."""
     data = await file.read()
-    force_local = local_only or localOnly or is_local_only(request)
     res = await asyncio.to_thread(
-        process_single_file, file.filename or "upload.bin", data, local_only=force_local
+        process_single_file, file.filename or "upload.bin", data
     )
     meta = res.pop("_meta", {})
     logger.info(
-        "single_generate llm_used=%s model=%s forced_local=%s",
+        "single_generate llm_used=%s model=%s",
         meta.get("llm_used"),
         meta.get("model"),
-        meta.get("forced_local"),
     )
     return {"kind": "insights", **res, "_meta": meta}
-

--- a/app/parsers/single_file.py
+++ b/app/parsers/single_file.py
@@ -9,8 +9,6 @@ async def analyze_single_file(
     name: str,
     bilingual: bool = True,
     no_speculation: bool = True,
-    *,
-    local_only: bool = False,
 ) -> Dict[str, Any]:
     """Analyze a single file by delegating to ChatGPT for insights.
 
@@ -19,6 +17,6 @@ async def analyze_single_file(
     offload the work to a thread via :func:`asyncio.to_thread` to avoid blocking
     the event loop.
     """
-    res = await asyncio.to_thread(process_single_file, name, data, local_only=local_only)
+    res = await asyncio.to_thread(process_single_file, name, data)
     res.pop("_meta", None)
     return {"report_type": "summary", **res, "source": name}

--- a/app/routers/drafts.py
+++ b/app/routers/drafts.py
@@ -12,8 +12,6 @@ router = APIRouter()
 @router.post("/drafts/from-file")
 async def from_file(
     file: UploadFile = File(...),
-    local_only: bool = Form(False),
-    localOnly: bool = Form(False),
 ):
     """Simplified single-file endpoint delegating work to ChatGPT.
 
@@ -23,18 +21,14 @@ async def from_file(
     """
     try:
         data = await file.read()
-        # Only honor explicit body flags for local mode; ignore headers/query params
-        force_local = bool(local_only or localOnly)
         res = await asyncio.to_thread(
-            process_single_file, file.filename, data, local_only=force_local
+            process_single_file, file.filename, data
         )
         meta = res.pop("_meta", {})
         logger.info(
-            "drafts/from-file llm_used=%s model=%s forced_local=%s fallback_reason=%s",
+            "drafts/from-file llm_used=%s model=%s",
             meta.get("llm_used"),
             meta.get("model"),
-            meta.get("forced_local"),
-            meta.get("fallback_reason"),
         )
         return {"kind": "insights", **res, "_meta": meta}
     except Exception as e:  # pragma: no cover - defensive

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -60,9 +60,6 @@ class DraftRequest(BaseModel):
     vendor_map: List[VendorMapRow] = Field(default_factory=list)
     category_map: List[CategoryMapRow] = Field(default_factory=list)
     config: ConfigModel = Field(default_factory=ConfigModel)
-    local_only: bool = Field(
-        default=False, validation_alias=AliasChoices("local_only", "localOnly")
-    )
 
 class DraftResponse(BaseModel):
     variance: VarianceItem

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,27 +1,24 @@
-import os
 from typing import Dict, Any, Tuple
 
 from app.schemas import GenerationMeta, TokenUsage
 from app.llm.openai_client import (
     build_client,
     get_openai_model,
-    get_fallback_policy,
     get_openai_key,
     OpenAIConfigError,
 )
 
-def llm_financial_summary(payload: Dict[str, Any], *, local_only: bool = False) -> Tuple[Dict[str, str], GenerationMeta]:
-    """
-    Build a concise, numbers-supported Summary / Financial Analysis / Financial Insights
-    strictly as plain text (no JSON, no markdown tables, no UI hints).
-    The model must cite quantities/totals that appear in the extracted data when possible.
-    """
+
+def llm_financial_summary(payload: Dict[str, Any]) -> Tuple[Dict[str, str], GenerationMeta]:
+    """Return summary, analysis and insights using the OpenAI API only."""
+    if not get_openai_key():
+        raise OpenAIConfigError("Missing OpenAI API key")
+
     lines = payload.get("lines", [])
     vendors = payload.get("vendors", [])
     totals = payload.get("totals", {})
-    raw_text = payload.get("raw_text", "")[:15000]  # keep prompt bounded
+    raw_text = payload.get("raw_text", "")[:15000]
 
-    # Lightweight guard: if key not present, keep empty — UI will still render
     prompt = f'''
 You are a financial analyst. The user uploaded a SINGLE FILE with NO budget/actual pairs.
 Return ONLY three plain-text sections in this exact order and nothing else:
@@ -44,88 +41,30 @@ Raw text (possibly noisy, use prudently):
 """{raw_text}"""
 '''
 
-    if not local_only:
-        try:  # pragma: no cover - network call
-            client = build_client()
-            msg = client.responses.create(
-                model=get_openai_model(),
-                temperature=0.2,
-                input=[
-                    {"role": "system", "content": "Be precise, numeric, and concise. Output plain text only."},
-                    {"role": "user", "content": prompt},
-                ],
-            )
-            text = (msg.output_text or "").strip()
-            usage = getattr(msg, "usage", None)
-            meta = GenerationMeta(
-                llm_used=True,
-                provider="OpenAI",
-                model=get_openai_model(),
-                token_usage=TokenUsage(
-                    prompt_tokens=getattr(usage, "input_tokens", None),
-                    completion_tokens=getattr(usage, "output_tokens", None),
-                    total_tokens=getattr(usage, "total_tokens", None),
-                ),
-                forced_local=False,
-            )
-        except Exception:
-            text = ""
-            meta = GenerationMeta(llm_used=False, forced_local=False)
-    else:
-        text = ""
-        meta = GenerationMeta(llm_used=False, forced_local=True)
-
+    client = build_client()
+    msg = client.responses.create(
+        model=get_openai_model(),
+        temperature=0.2,
+        input=[
+            {"role": "system", "content": "Be precise, numeric, and concise. Output plain text only."},
+            {"role": "user", "content": prompt},
+        ],
+    )
+    text = (msg.output_text or "").strip()
     if not text:
-        # Fallback when the OpenAI client isn't configured or errors out. We still
-        # want to provide the caller with something meaningful so the UI can render
-        # useful text instead of empty strings.
-        import re
-
-        text = raw_text.strip()
-        if not text:
-            # Nothing could be extracted from the file; surface explicit placeholders
-            return (
-                {
-                    "summary_text": "No textual content could be extracted from the document.",
-                    "analysis_text": "No numeric data found for analysis.",
-                    "insights_text": "No financial insights identified.",
-                    "source": "local",
-                },
-                meta,
-            )
-
-        # crude summary: first 40 words from the raw text
-        words = re.findall(r"\w+", text)
-        summary = " ".join(words[:40]) if words else text[:200]
-
-        # attempt to extract numeric values for a rudimentary analysis
-        nums = [
-            float(n.replace(",", ""))
-            for n in re.findall(r"[-+]?[0-9,]*\.?[0-9]+", text)
-        ]
-        if nums:
-            total = sum(nums)
-            avg = total / len(nums)
-            analysis = (
-                f"The document references {len(nums)} numeric values totalling"
-                f" approximately {total:.2f} with an average of {avg:.2f}."
-            )
-            insights = "High or unusual figures may warrant further review."
-        else:
-            analysis = "No numeric data found for analysis."
-            insights = "No financial insights identified."
-
-        return (
-            {
-                "summary_text": summary,
-                "analysis_text": analysis,
-                "insights_text": insights,
-                "source": "local",
-            },
-            meta,
-        )
-
-    # Very light splitter: try to split into 3 blocks; if not, put everything in 'summary_text'
+        raise RuntimeError("Empty response from OpenAI")
+    usage = getattr(msg, "usage", None)
+    meta = GenerationMeta(
+        llm_used=True,
+        provider="OpenAI",
+        model=get_openai_model(),
+        token_usage=TokenUsage(
+            prompt_tokens=getattr(usage, "input_tokens", None),
+            completion_tokens=getattr(usage, "output_tokens", None),
+            total_tokens=getattr(usage, "total_tokens", None),
+        ),
+        forced_local=False,
+    )
     blocks = [b.strip() for b in text.split("\n\n") if b.strip()]
     out = {"summary_text": text, "analysis_text": "", "insights_text": "", "source": "llm"}
     if len(blocks) >= 3:
@@ -133,98 +72,56 @@ Raw text (possibly noisy, use prudently):
             "summary_text": blocks[0],
             "analysis_text": blocks[1],
             "insights_text": "\n\n".join(blocks[2:]),
+            "source": "llm",
         }
     return out, meta
 
 
-def llm_financial_summary_file(filename: str, data: bytes, *, local_only: bool = False) -> Tuple[Dict[str, str], Dict[str, Any]]:
-    """Send a raw uploaded file to ChatGPT for three text sections with fallback.
-
-    Local mode is used only when explicitly requested or when the configured
-    fallback policy allows it.
-    """
-
-    def _local_summary() -> Tuple[Dict[str, str], Dict[str, Any]]:
-        from app.utils.file_to_text import file_bytes_to_text
-
-        raw_text = file_bytes_to_text(filename, data)
-        out, _ = llm_financial_summary({"raw_text": raw_text}, local_only=True)
-        meta_local = {
-            "provider": "local",
-            "model": None,
-            "llm_used": "local",
-            "fallback_reason": meta.get("fallback_reason", "none"),
-        }
-        return out, meta_local
-
-    meta: Dict[str, Any] = {
-        "provider": None,
-        "model": None,
-        "llm_used": None,
-        "fallback_reason": "none",
-    }
-
-    if local_only:
-        return _local_summary()
-
-    policy = get_fallback_policy()
-    key = get_openai_key()
-    if not key:
-        if policy in {"if_no_key", "on_error"}:
-            meta["fallback_reason"] = "no_api_key"
-            return _local_summary()
+def llm_financial_summary_file(filename: str, data: bytes) -> Tuple[Dict[str, str], Dict[str, Any]]:
+    """Send a raw uploaded file to ChatGPT for three text sections."""
+    if not get_openai_key():
         raise OpenAIConfigError("Missing OpenAI API key")
 
-    try:  # pragma: no cover - network call
-        client = build_client()
-        model = get_openai_model()
-        upload = client.files.create(file=data, purpose="assistants", filename=filename)
-        resp = client.responses.create(
-            model=model,
-            input=[
-                {
-                    "role": "system",
-                    "content": "Be precise, numeric, and concise. Output plain text only.",
-                },
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_text",
-                            "text": (
-                                "Review the attached document and return three plain-text "
-                                "sections: Summary, Financial analysis, Financial insights."
-                            ),
-                        },
-                        {"type": "input_file", "file_id": upload.id},
-                    ],
-                },
-            ],
-        )
-        text = (resp.output_text or "").strip()
-        usage = getattr(resp, "usage", None)
-        meta.update(
+    client = build_client()
+    model = get_openai_model()
+    upload = client.files.create(file=data, purpose="assistants", filename=filename)
+    resp = client.responses.create(
+        model=model,
+        input=[
             {
-                "provider": "openai",
-                "model": model,
-                "llm_used": "openai",
-                "token_usage": {
-                    "prompt_tokens": getattr(usage, "input_tokens", None),
-                    "completion_tokens": getattr(usage, "output_tokens", None),
-                    "total_tokens": getattr(usage, "total_tokens", None),
-                },
-            }
-        )
-    except Exception as e:
-        if policy in {"on_error"}:
-            meta["fallback_reason"] = f"openai_error:{type(e).__name__}"
-            return _local_summary()
-        raise
-
+                "role": "system",
+                "content": "Be precise, numeric, and concise. Output plain text only.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "Review the attached document and return three plain-text "
+                            "sections: Summary, Financial analysis, Financial insights."
+                        ),
+                    },
+                    {"type": "input_file", "file_id": upload.id},
+                ],
+            },
+        ],
+    )
+    text = (resp.output_text or "").strip()
     if not text:
-        meta["fallback_reason"] = "openai_error:empty_response"
-        return _local_summary()
-
+        raise RuntimeError("Empty response from OpenAI")
+    usage = getattr(resp, "usage", None)
+    meta: Dict[str, Any] = {
+        "provider": "openai",
+        "model": model,
+        "llm_used": "openai",
+        "token_usage": {
+            "prompt_tokens": getattr(usage, "input_tokens", None),
+            "completion_tokens": getattr(usage, "output_tokens", None),
+            "total_tokens": getattr(usage, "total_tokens", None),
+        },
+        "forced_local": False,
+    }
     blocks = [b.strip() for b in text.split("\n\n") if b.strip()]
     out = {"summary_text": text, "analysis_text": "", "insights_text": "", "source": "llm"}
     if len(blocks) >= 3:

--- a/app/services/singlefile.py
+++ b/app/services/singlefile.py
@@ -4,14 +4,12 @@ from typing import Dict, Any
 
 from app.services.llm import llm_financial_summary_file
 from app.utils.retries import retry_call
-from app.config import FORCE_LLM
 
 
 def process_single_file(
     filename: str,
     data: bytes,
     *_,
-    local_only: bool = False,
     **__,
 ) -> Dict[str, Any]:
     """Send a single uploaded file directly to ChatGPT for analysis.
@@ -21,13 +19,9 @@ def process_single_file(
     insights. Metadata about the generation is returned under ``_meta``.
     """
 
-    # LLM-only: no fallbacks. Use retries for transient failures, then raise.
-    effective_local = False if FORCE_LLM else bool(local_only)
-    res, meta = retry_call(
-        llm_financial_summary_file, filename, data, local_only=effective_local
-    )
-    meta["forced_local"] = effective_local
-    res["model_family"] = "local" if effective_local else "chatgpt"
+    res, meta = retry_call(llm_financial_summary_file, filename, data)
+    meta["forced_local"] = False
+    res["model_family"] = "chatgpt"
     res["_meta"] = meta
     return res
 

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -3,7 +3,6 @@ async function generateFromSingleFile() {
   if (!file) return;
   const fd = new FormData();
   fd.append('file', file);
-  fd.append('local_only', document.getElementById('optLocalOnly')?.checked ? 'true' : 'false');
 
   const resp = await fetch('/drafts/from-file', { method: 'POST', body: fd });
   let data = {};
@@ -51,8 +50,7 @@ function renderSummaryAnalysisInsightsOnly(payload) {
   const { summary_text = '', analysis_text = '', insights_text = '', model_family = '' } = payload || {};
 
   const label =
-    model_family === 'chatgpt' ? 'Generated via ChatGPT' :
-    model_family === 'local'   ? 'Generated locally'     : '';
+    model_family === 'chatgpt' ? 'Generated via ChatGPT' : '';
   const badge = label ? `<span class="pill">${label}</span>` : '';
 
   const parts = []

--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -396,7 +396,6 @@
       fd.append('file', f);
       fd.append('bilingual', $('optBilingual').checked ? 'true' : 'false');
       fd.append('no_speculation', $('optNoSpec').checked ? 'true' : 'false');
-      fd.append('local_only', $('optLocalOnly').checked ? 'true' : 'false');
       setStatus('Calling API…'); setBar(60); $('btnSingle').disabled = true;
       const resp = await fetch('/drafts/from-file', { method: 'POST', body: fd });
       if (!resp.ok) {
@@ -455,7 +454,6 @@
           enforce_no_speculation: $('optNoSpec').checked
         }
       };
-      payload.local_only = $('optLocalOnly').checked;
 
       // quick guard: require at least Budget–Actuals
       if (!payload.budget_actuals.length) {

--- a/app/utils/local.py
+++ b/app/utils/local.py
@@ -2,17 +2,11 @@ from fastapi import Request
 
 
 def is_local_only(request: Request) -> bool:
-    """Return True if the client requested local-only processing.
+    """Always return ``False`` as local-only mode is disabled.
 
-    Accepts both snake_case and camelCase variations in headers or query
-    parameters (``local_only`` / ``localOnly``).  A truthy value such as
-    ``"true"`` or ``"1"`` triggers local-only mode.
+    The application previously supported bypassing the LLM and generating
+    drafts locally.  This behaviour has been removed so that all outputs are
+    AI-assisted.  The helper now ignores any request flags and simply returns
+    ``False``.
     """
-    val = (
-        request.headers.get("x-local-only")
-        or request.headers.get("local-only")
-        or request.query_params.get("localOnly")
-        or request.query_params.get("local_only")
-        or ""
-    ).lower()
-    return val in ("1", "true", "yes")
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,3 +2,33 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import types
+import pytest
+
+
+@pytest.fixture
+def dummy_llm(monkeypatch):
+    """Provide a dummy OpenAI client for tests."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    class DummyClient:
+        class files:
+            @staticmethod
+            def create(file, purpose, filename):
+                return types.SimpleNamespace(id="file123")
+
+        class responses:
+            @staticmethod
+            def create(*args, **kwargs):
+                return types.SimpleNamespace(
+                    output_text="Summary\n\nAnalysis\n\nInsights",
+                    usage=types.SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                )
+
+    monkeypatch.setattr("openai_client_helper.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
+    monkeypatch.setattr("app.gpt_client.build_client", lambda: DummyClient())
+    yield
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_analyze_single_file_no_cards.py
+++ b/tests/test_analyze_single_file_no_cards.py
@@ -4,7 +4,7 @@ import asyncio
 from app.parsers.single_file import analyze_single_file
 
 
-def test_analyze_single_file_discards_cards():
+def test_analyze_single_file_discards_cards(dummy_llm):
     pdf_path = pathlib.Path('samples/procurement_example.pdf')
     data = pdf_path.read_bytes()
     res = asyncio.run(analyze_single_file(data, pdf_path.name))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ def _load_csv(path: Path):
         return list(csv.DictReader(f))
 
 
-def test_create_drafts_endpoint():
+def test_create_drafts_endpoint(dummy_llm):
     base = Path('data/templates')
     payload = {
         'budget_actuals': _load_csv(base / 'budget_actuals.csv'),

--- a/tests/test_doors_quotes_adapter.py
+++ b/tests/test_doors_quotes_adapter.py
@@ -1,5 +1,8 @@
 import io
 import pandas as pd
+import io
+import pandas as pd
+
 from app.services.singlefile import process_single_file
 
 
@@ -30,7 +33,7 @@ def _build_workbook():
     return bio.getvalue()
 
 
-def test_doors_quotes_adapter_handles_workbook():
+def test_doors_quotes_adapter_handles_workbook(dummy_llm):
     data = _build_workbook()
     resp = process_single_file('doors_quotes.xlsx', data)
     assert 'summary_text' in resp

--- a/tests/test_drafts_from_file_multisheet.py
+++ b/tests/test_drafts_from_file_multisheet.py
@@ -23,7 +23,7 @@ def _multi_sheet_bytes() -> bytes:
     return buf.getvalue()
 
 
-def test_drafts_from_file_returns_insights():
+def test_drafts_from_file_returns_insights(dummy_llm):
     client = TestClient(app)
     files = {
         "file": (

--- a/tests/test_from_file_no_variance_returns_summary_and_insights.py
+++ b/tests/test_from_file_no_variance_returns_summary_and_insights.py
@@ -3,7 +3,7 @@ from app.main import app, require_api_key
 
 app.dependency_overrides[require_api_key] = lambda: None
 
-def test_from_file_no_variance():
+def test_from_file_no_variance(dummy_llm):
     client = TestClient(app)
     files = {"file": ("note.txt", b"Procurement lines only, no budget/actuals", "text/plain")}
     r = client.post("/drafts/from-file", files=files)

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from app.gpt_client import generate_draft
 from app.schemas import VarianceItem, ConfigModel
 
@@ -34,12 +35,10 @@ def test_generate_draft_timeout(monkeypatch):
         vendors=["Vendor"],
     )
     cfg = ConfigModel()
-    en, ar, meta = generate_draft(v, cfg)
-    assert "variance" in en
+    with pytest.raises(TimeoutError):
+        generate_draft(v, cfg)
     assert DummyOpenAI.last_kwargs["timeout"] == 1
     assert DummyOpenAI.last_kwargs["max_retries"] == 5
-    assert ar  # bilingual fallback text
-    assert meta.llm_used is False
     os.environ.pop("OPENAI_API_KEY")
     os.environ.pop("OPENAI_TIMEOUT")
     os.environ.pop("OPENAI_MAX_RETRIES")

--- a/tests/test_pdf_no_variance_returns_summary_and_insights.py
+++ b/tests/test_pdf_no_variance_returns_summary_and_insights.py
@@ -4,7 +4,7 @@ import pathlib
 
 app.dependency_overrides[require_api_key] = lambda: None
 
-def test_pdf_no_variance():
+def test_pdf_no_variance(dummy_llm):
     client = TestClient(app)
     pdf_path = pathlib.Path('samples/procurement_example.pdf')
     files = {"file": (pdf_path.name, pdf_path.read_bytes(), "application/pdf")}

--- a/tests/test_single_file_llm_routing.py
+++ b/tests/test_single_file_llm_routing.py
@@ -1,6 +1,6 @@
-from fastapi.testclient import TestClient
 import types
 import pytest
+from fastapi.testclient import TestClient
 
 from app.main import app, require_api_key
 from app.services.singlefile import process_single_file
@@ -16,119 +16,38 @@ class DummyClient:
 
     class responses:
         @staticmethod
-        def create(model, input):
+        def create(*args, **kwargs):
             return types.SimpleNamespace(
                 output_text="Summary\n\nAnalysis\n\nInsights",
                 usage=types.SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
             )
 
 
-def test_single_file_local_only_true_uses_local(monkeypatch):
+def test_local_only_flag_ignored(dummy_llm):
     client = TestClient(app)
     files = {"file": ("note.txt", b"hi", "text/plain")}
     r = client.post("/drafts/from-file", files=files, data={"local_only": "true"})
     assert r.status_code == 200
     meta = r.json()["_meta"]
-    assert meta["llm_used"] == "local"
-    assert meta["provider"] == "local"
-    assert meta["forced_local"] is True
-
-
-def test_single_file_no_local_flag_uses_openai(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
-    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
-    client = TestClient(app)
-    files = {"file": ("note.txt", b"hi", "text/plain")}
-    r = client.post("/drafts/from-file", files=files)
-    assert r.status_code == 200
-    meta = r.json()["_meta"]
     assert meta["llm_used"] == "openai"
-    assert meta["provider"] == "openai"
-    assert meta["model"] == "gpt-4o-mini"
-    assert meta["forced_local"] is False
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
-def test_headers_ignored_for_local_only(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
-    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
+def test_headers_ignored_for_local_only(dummy_llm):
     client = TestClient(app)
     files = {"file": ("note.txt", b"hi", "text/plain")}
     r = client.post("/drafts/from-file", files=files, headers={"x-local-only": "true"})
     assert r.status_code == 200
     meta = r.json()["_meta"]
     assert meta["llm_used"] == "openai"
+
+
+def test_missing_key_raises(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-
-def test_force_llm_overrides_local_flag(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setattr("app.services.singlefile.FORCE_LLM", True, raising=False)
-    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: DummyClient())
-    monkeypatch.setattr("app.services.llm.build_client", lambda: DummyClient())
-    client = TestClient(app)
-    files = {"file": ("note.txt", b"hi", "text/plain")}
-    r = client.post("/drafts/from-file", files=files, data={"local_only": "true"})
-    assert r.status_code == 200
-    meta = r.json()["_meta"]
-    assert meta["llm_used"] == "openai"
-    assert meta["forced_local"] is False
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-
-def test_fallback_policy_on_error_missing_key(monkeypatch):
-    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "on_error")
-    res = process_single_file("note.txt", b"hi")
-    meta = res["_meta"]
-    assert meta["llm_used"] == "local"
-    assert meta["fallback_reason"] == "no_api_key"
-    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
-
-
-def test_fallback_policy_on_error_openai_exception(monkeypatch):
-    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "on_error")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-
-    class BoomClient(DummyClient):
-        class responses:
-            @staticmethod
-            def create(*args, **kwargs):
-                raise RuntimeError("boom")
-
-    monkeypatch.setattr("app.llm.openai_client.build_client", lambda: BoomClient())
-    monkeypatch.setattr("app.services.llm.build_client", lambda: BoomClient())
-    res = process_single_file("note.txt", b"hi")
-    meta = res["_meta"]
-    assert meta["llm_used"] == "local"
-    assert meta["fallback_reason"].startswith("openai_error")
-    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-
-def test_fallback_policy_never_missing_key(monkeypatch):
-    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "never")
-    try:
+    with pytest.raises(OpenAIConfigError):
         process_single_file("note.txt", b"hi")
-    except OpenAIConfigError:
-        pass
-    else:
-        assert False, "Expected OpenAIConfigError"
-    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
 
 
-def test_fallback_policy_if_no_key(monkeypatch):
-    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "if_no_key")
-    res = process_single_file("note.txt", b"hi")
-    meta = res["_meta"]
-    assert meta["llm_used"] == "local"
-    assert meta["fallback_reason"] == "no_api_key"
-    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
-
-
-def test_fallback_policy_if_no_key_openai_error(monkeypatch):
-    monkeypatch.setenv("LOCAL_FALLBACK_POLICY", "if_no_key")
+def test_openai_error_propagates(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     class BoomClient(DummyClient):
@@ -141,5 +60,4 @@ def test_fallback_policy_if_no_key_openai_error(monkeypatch):
     monkeypatch.setattr("app.services.llm.build_client", lambda: BoomClient())
     with pytest.raises(RuntimeError):
         process_single_file("note.txt", b"hi")
-    monkeypatch.delenv("LOCAL_FALLBACK_POLICY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_single_generate_procurement.py
+++ b/tests/test_single_generate_procurement.py
@@ -5,7 +5,7 @@ from app.main import app
 import app.api as _api  # noqa: F401 - ensure /single/generate route is registered
 
 
-def test_single_generate_returns_summary_analysis_insights():
+def test_single_generate_returns_summary_analysis_insights(dummy_llm):
     client = TestClient(app)
     pdf_path = Path(__file__).resolve().parent.parent / "samples" / "procurement_example.pdf"
     with pdf_path.open("rb") as f:
@@ -16,10 +16,10 @@ def test_single_generate_returns_summary_analysis_insights():
     assert "analysis_text" in data and isinstance(data["analysis_text"], str)
     assert "insights_text" in data and isinstance(data["insights_text"], str)
     assert "analysis" not in data and "insights" not in data
-    assert data.get("model_family") in ("chatgpt", "local")
+    assert data.get("model_family") == "chatgpt"
 
 
-def test_single_generate_respects_local_only_flag():
+def test_single_generate_respects_local_only_flag(dummy_llm):
     client = TestClient(app)
     pdf_path = Path(__file__).resolve().parent.parent / "samples" / "procurement_example.pdf"
     with pdf_path.open("rb") as f:
@@ -30,4 +30,4 @@ def test_single_generate_respects_local_only_flag():
         )
     assert resp.status_code == 200
     data = resp.json()
-    assert data.get("model_family") == "local"
+    assert data.get("model_family") == "chatgpt"

--- a/tests/test_singlefile_doors_quotes_like.py
+++ b/tests/test_singlefile_doors_quotes_like.py
@@ -1,4 +1,5 @@
 import io
+import io
 import pandas as pd
 
 from app.services.singlefile import process_single_file
@@ -11,7 +12,7 @@ def _xlsx_bytes(df: pd.DataFrame) -> bytes:
     return bio.getvalue()
 
 
-def test_doors_quotes_like_excel_returns_summary():
+def test_doors_quotes_like_excel_returns_summary(dummy_llm):
     data = [
         ["Vendor:", "AL AZAL", "", "", ""],
         ["", "", "", "", ""],

--- a/tests/test_singlefile_pdf.py
+++ b/tests/test_singlefile_pdf.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from app.services.singlefile import process_single_file
 
 
-def test_pdf_produces_summary_and_insights():
+def test_pdf_produces_summary_and_insights(dummy_llm):
     data = Path('samples/procurement_example.pdf').read_bytes()
     res = process_single_file('procurement_example.pdf', data)
     assert 'summary_text' in res and isinstance(res['summary_text'], str)
@@ -15,4 +15,4 @@ def test_pdf_produces_summary_and_insights():
     assert 'analysis' not in res and 'insights' not in res
     assert 'items' not in res
     assert 'mode' not in res
-    assert res.get('model_family') in ('chatgpt', 'local')
+    assert res.get('model_family') == 'chatgpt'


### PR DESCRIPTION
## Summary
- remove local-only generation paths and require OpenAI for all drafts
- drop local-only flags from APIs, UI and schemas
- update tests to expect AI-generated outputs only

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdff9055a8832a96dbc22df8fc1c4f