### PR TITLE
refactor: centralize OpenAI file uploads

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,3 +1,4 @@
+from openai_file_upload import upload_bytes_as_file
 from typing import Dict, Any, Tuple
 
 from app.schemas import GenerationMeta, TokenUsage
@@ -84,7 +85,7 @@ def llm_financial_summary_file(filename: str, data: bytes) -> Tuple[Dict[str, st
 
     client = build_client()
     model = get_openai_model()
-    upload = client.files.create(file=data, purpose="assistants", filename=filename)
+    file_id = upload_bytes_as_file(data, filename)
     resp = client.responses.create(
         model=model,
         input=[
@@ -102,7 +103,7 @@ def llm_financial_summary_file(filename: str, data: bytes) -> Tuple[Dict[str, st
                             "sections: Summary, Financial analysis, Financial insights."
                         ),
                     },
-                    {"type": "input_file", "file_id": upload.id},
+                    {"type": "input_file", "file_id": file_id},
                 ],
             },
         ],

--- a/openai_file_upload.py
+++ b/openai_file_upload.py
@@ -1,0 +1,23 @@
+from openai import OpenAI
+import io
+from pathlib import Path
+from typing import Union
+
+
+def _get_client() -> OpenAI:
+    return OpenAI()
+
+
+def upload_bytes_as_file(data: bytes, filename: str, purpose: str = "assistants") -> str:
+    """Upload in-memory bytes to OpenAI Files (SDK v1.x). Returns file_id."""
+    bio = io.BytesIO(data)
+    bio.name = filename  # optional friendly name
+    client = _get_client()
+    return client.files.create(file=bio, purpose=purpose).id
+
+
+def upload_path_as_file(path: Union[str, Path], purpose: str = "assistants") -> str:
+    """Upload a local path to OpenAI Files (SDK v1.x). Returns file_id."""
+    p = Path(path)
+    client = _get_client()
+    return client.files.create(file=p, purpose=purpose).id


### PR DESCRIPTION
## Summary
- add helper module for OpenAI file uploads
- use helper in `llm_financial_summary_file` for uploading bytes

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: openai.AuthenticationError: Incorrect API key provided: sk-test; KeyError: 'kind'; assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a7dedc8832ab55b0b664ddbf4cf