### PR TITLE
Remove local-only mode option from UI

### DIFF
--- a/app/templates/ui.html
+++ b/app/templates/ui.html
@@ -91,7 +91,6 @@
           <div class="row">
             <label><input id="optBilingual" type="checkbox" checked /> Bilingual</label>
             <label><input id="optNoSpec" type="checkbox" checked /> No speculation</label>
-            <label><input id="optLocalOnly" type="checkbox" /> Local-only mode</label>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove obsolete "Local-only mode" checkbox from the upload options in UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be17b5d588832a8969330805f8324c